### PR TITLE
Implement a publisher backlist cover fetcher 

### DIFF
--- a/managers/coverFetchers/publisher_backlist_cover_fetcher.py
+++ b/managers/coverFetchers/publisher_backlist_cover_fetcher.py
@@ -1,0 +1,80 @@
+import hashlib
+import io
+import os
+
+import PIL
+import pypdf
+import requests
+import requests.exceptions
+
+from logger import create_log
+from managers.coverFetchers.abstractFetcher import AbstractFetcher
+
+logger = create_log(__name__)
+
+
+class PublisherBacklistCoverFetcher(AbstractFetcher):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        self.session = requests.Session()
+        self.bucket = os.environ["FILE_BUCKET"]
+        self.pdf_url: str | None = None
+
+
+    def hasCover(self):
+        for value, source in self.identifiers:
+            if source != "hathi":
+                continue
+
+            url = (
+                f"https://{self.bucket}.s3.us-east-1.amazonaws.com"
+                f"/titles/publisher_backlist/Schomburg/{value}/{value}.pdf"
+            )
+
+            response = self.session.head(url)
+
+            try:
+                response.raise_for_status()
+            except requests.exceptions.HTTPError:
+                continue
+            except Exception as e:
+                logger.exception("Unexpected error when fetching PDF")
+                continue
+            else:
+                self.pdf_url = url
+                return True
+
+        return False
+
+    def downloadCoverFile(self) -> bytes:
+        with io.BytesIO() as stream:
+            response = self.session.get(self.pdf_url, stream=True)
+            response.raise_for_status()
+            for chunk in response.iter_content(chunk_size=8192):
+                stream.write(chunk)
+
+            with pypdf.PdfReader(stream) as pdf:
+                image = PublisherBacklistCoverFetcher.find_cover_in_pdf(pdf)
+
+        with io.BytesIO() as outstream:
+            # image.tobytes() returns Pillow's internal image representation, which appears
+            # to not be a file type that is generally readable by a browser or Preview.
+            # Instead, write to a stream using the`save` method, and read the bytes off the
+            # stream
+            image.save(outstream, format="PNG")
+            return outstream.getvalue()
+
+
+    @staticmethod
+    def find_cover_in_pdf(pdf: pypdf.PdfReader) -> PIL.Image:
+        for page in pdf.pages:
+            image = page.images[0].image
+            if page.extract_text():
+                return image
+
+            if image.entropy() < 0.001:
+                continue
+
+            return image

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ python-levenshtein==0.20.4
 pycountry==22.3.5
 pyjwt[crypto]==2.6.0
 pymarc==4.2.2
+pypdf==5.4.0
 pyyaml==6.0
 redis==4.5.4
 requests==2.28.2


### PR DESCRIPTION
Add a new cover fetcher that looks for PDFs in DRBs publisher backlist directory in s3 and tries to "infer" a cover from a PDF, by looking for the first page in the PDF with a non-empty appearing image.

For determining "non-empty" images, we use the pillow package's entropy value, since these images are scans, and the blank images that sometimes are included in the PDF before the actual cover are not true blanks (ie, there are minor variations in pixel color)

Also note, instead of using the S3 API to access the files, I opted to use directly fetch the object urls using http requests, since the objects are public, and so that this could potentially be adapted to non-DRB hosted PDFs that are missing cover images.

A few open questions:

  1. I hardcoded 'Schomburg' into the s3 path, since those are the only backlist titles for now. However, maybe it makes sense to either move the PDFs into a folder without the backlist source in the name, so that this could work in the future for non-Schomburg titles?
  2. Should I set an explicit fetcher priority here? Might make sense to prioritize this last, since this fetcher is kind of guessing 🤷 
  3. Should I make this generic to any publicly downloadable PDF? The one thing I think preventing that is that the abstract fetcher class only has access to identifiers, so figuring out the url would require some changes to how the fetchers are constructed / used.  Happy to implement that though!

