### PR TITLE
Load env file for non-unit tests

### DIFF
--- a/etl-pipeline/tests/conftest.py
+++ b/etl-pipeline/tests/conftest.py
@@ -53,9 +53,9 @@ def create_or_update_record(record_data: dict, db_manager: DBManager) -> Record:
 def setup_env(pytestconfig, request):
     environment = os.environ.get('ENVIRONMENT') or pytestconfig.getoption('--env') or 'local'
 
-    running_unit_tests = any('unit' in item.keywords for item in request.session.items)
+    running_functional_integration_tests = any('functional' in item.keywords or 'integration' in item.keywords for item in request.session.items)
 
-    if not running_unit_tests and environment in ['local', 'local-qa', 'qa']:
+    if running_functional_integration_tests and environment in ['local', 'local-qa', 'qa']:
         load_env_file(environment, file_string=f'config/{environment}.yaml')
 
 


### PR DESCRIPTION
## Describe your changes
Currently, when you run the entire test suite, it fails to load the configuration file (`local.yaml`) because the testrun includes `unit` tests. The variables in the config file are necessary for functional and integration tests to pass. This PR makes it so that if functional or integration tests are being run, the config file will be loaded.

## How to test
Run the entire test suite by doing: `pytest tests` or `python -m pytest`