### PR TITLE
Generate covers during publisher backlist ingest

### DIFF
--- a/etl-pipeline/managers/pdf_cover_generator.py
+++ b/etl-pipeline/managers/pdf_cover_generator.py
@@ -1,0 +1,51 @@
+import io
+import os
+
+import PIL
+import pypdf
+import requests
+import requests.exceptions
+
+from logger import create_log
+
+logger = create_log(__name__)
+
+
+class PDFCoverGenerator:
+
+    def __init__(self, pdf_content: io.BytesIO):
+
+        self.pdf = pypdf.PdfReader(pdf_content)
+
+    @staticmethod
+    def from_url(pdf_url: str) -> "PDFCoverGenerator":
+        stream = io.BytesIO()
+        logger.info("Fetching PDF from url %s", pdf_url)
+        response = requests.get(pdf_url, stream=True)
+        response.raise_for_status()
+        for chunk in response.iter_content(chunk_size=8192):
+            stream.write(chunk)
+
+        return PDFCoverGenerator(stream)
+
+    def extract_cover_content(self, outstream: io.BytesIO) -> None:
+        image = self._extract_cover_image()
+        image.save(outstream, format="PNG")
+        # Move the stream pointer back to the front now that we're done writing
+        outstream.seek(0)
+
+    def _extract_cover_image(self) -> PIL.Image:
+        for page in self.pdf.pages:
+            image = page.images[0].image
+            if page.extract_text():
+                logger.info("Found first page with text, returning as cover")
+                return image
+
+            if image.entropy() < 0.001:
+                logger.info("Likely blank image detected, skipping")
+                continue
+
+            return image
+
+        # Default to the first page
+        return self.pdf.pages[0]

--- a/etl-pipeline/requirements.txt
+++ b/etl-pipeline/requirements.txt
@@ -18,6 +18,7 @@ pandas==2.0.0
 pika==1.3.1
 pillow==9.5.0
 psycopg2-binary==2.9.6
+pypdf==5.4.0
 python-levenshtein==0.20.4
 pycountry==22.3.5
 pyjwt[crypto]==2.6.0

--- a/etl-pipeline/services/sources/publisher_backlist_service.py
+++ b/etl-pipeline/services/sources/publisher_backlist_service.py
@@ -212,7 +212,7 @@ class PublisherBacklistService(SourceService):
                         index=2,
                         url=cover_url,
                         source=publisher_backlist_record.record.source,
-                        file_type="application/png",
+                        file_type="image/png",
                         flags=str(FileFlags(cover=True)),
                     )))
 

--- a/etl-pipeline/services/sources/publisher_backlist_service.py
+++ b/etl-pipeline/services/sources/publisher_backlist_service.py
@@ -324,7 +324,7 @@ class PublisherBacklistService(SourceService):
         return f"&filterByFormula=AND(OR({is_same_date_time_filter}),{is_after_date_time_filter})),{ready_to_ingest_filter},{is_not_deleted_filter})"
 
     @staticmethod
-    def get_hathi_id(record) -> int | None:
+    def get_hathi_id(record) -> Optional[str]:
         hath_identifier = next((identifier for identifier in record.identifiers if identifier.endswith('hathi')), None)
 
         if hath_identifier is not None:

--- a/etl-pipeline/services/sources/publisher_backlist_service.py
+++ b/etl-pipeline/services/sources/publisher_backlist_service.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import io
 import os
 import boto3
 import requests
@@ -11,6 +12,7 @@ from sqlalchemy.orm import joinedload
 from digital_assets import get_stored_file_url
 from logger import create_log
 from mappings.publisher_backlist import PublisherBacklistMapping
+from managers.pdf_cover_generator import PDFCoverGenerator
 from managers import S3Manager
 from services.ssm_service import SSMService
 from services.google_drive_service import GoogleDriveService
@@ -179,18 +181,21 @@ class PublisherBacklistService(SourceService):
             try:
                 record_metadata = record.get('fields')
                 record_permissions = self.parse_permissions(record_metadata.get('Access type in DRB (from Access types)')[0])
-                
+
                 publisher_backlist_record = PublisherBacklistMapping(record_metadata)
                 publisher_backlist_record.applyMapping()
-                
+                hathi_id = PublisherBacklistService.get_hathi_id(publisher_backlist_record.record)
+                if not hathi_id:
+                    continue
+
                 try:
-                    file_url = self.download_file_from_location(record_metadata, record_permissions, publisher_backlist_record.record)
+                    file_url = self.download_file_from_location(hathi_id, record_metadata, record_permissions, publisher_backlist_record.record)
                     if not file_url:
                         continue
                 except Exception:
                     logger.exception(f'Failed to download file for {record}')
                     continue
-                
+
                 publisher_backlist_record.record.has_part.append(str(Part(
                     index=1,
                     url=file_url,
@@ -198,6 +203,19 @@ class PublisherBacklistService(SourceService):
                     file_type='application/pdf',
                     flags=str(FileFlags(download=record_permissions['is_downloadable'], nypl_login=record_permissions['requires_login']))
                 )))
+                try:
+                    cover_url = self.extract_cover_url(hathi_id)
+                except Exception:
+                    logger.exception("Failed to generate cover")
+                else:
+                    publisher_backlist_record.record.has_part.append(str(Part(
+                        index=2,
+                        url=cover_url,
+                        source=publisher_backlist_record.record.source,
+                        file_type="application/png",
+                        flags=str(FileFlags(cover=True)),
+                    )))
+
                 self.s3_manager.store_pdf_manifest(publisher_backlist_record.record, self.file_bucket, flags=FileFlags(reader=True, nypl_login=record_permissions['requires_login']), path='publisher_backlist')
                 mapped_records.append(publisher_backlist_record)
             except Exception:
@@ -206,56 +224,70 @@ class PublisherBacklistService(SourceService):
                 )
 
         return mapped_records
-    
-    def download_file_from_location(self, record_metadata: dict, record_permissions: dict, record: Record) -> str:
+
+    def extract_cover_url(self, hathi_id: str) -> str:
+        bucket = self.file_bucket
+        cover_key = f"covers/publisher_backlist/hathi_{hathi_id}.png"
+        try:
+            self.s3_manager.client.head_object(Bucket=bucket, Key=cover_key)
+        except Exception:
+            logger.info("Cover not found, generating one instead")
+        else:
+            return get_stored_file_url(bucket, cover_key)
+
+        pdf_url = get_stored_file_url(bucket, f"titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf")
+        cover_generator = PDFCoverGenerator.from_url(pdf_url)
+        with io.BytesIO() as stream:
+            logger.info("Extracting cover")
+            cover_generator.extract_cover_content(stream)
+            logger.info("Uploading cover")
+            self.s3_manager.client.upload_fileobj(stream, bucket, cover_key)
+
+        return get_stored_file_url(bucket, cover_key)
+
+    def download_file_from_location(self, hathi_id: str, record_metadata: dict, record_permissions: dict, record: Record) -> str:
         file_location = record_metadata.get('DRB_File Location')
-        destination_file_bucket = os.environ.get("FILE_BUCKET", "drb-files-local")
-
+        destination_file_bucket = self.file_bucket
         if not file_location:
-            hath_identifier = next((identifier for identifier in record.identifiers if identifier.endswith('hathi')), None)
+            destination_pdf_url = get_stored_file_url(
+                storage_name=destination_file_bucket,
+                file_path=f'titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf',
+            )
 
-            if hath_identifier is not None:
-                hathi_id = hath_identifier.split('|')[0]
+            try:
+                self.s3_manager.client.head_object(Bucket=destination_file_bucket, Key=f'titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf')
+                logger.info(f'PDF already exists at key: titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf')
+                return destination_pdf_url
+            except Exception:
+                logger.exception(f'PDF does not exist at key: titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf')
 
+            try:
+                pdf_bucket = os.environ["PDF_BUCKET"]
+                self.s3_manager.client.head_object(Bucket=pdf_bucket, Key=f'tagged_pdfs/{hathi_id}.pdf')
+            except Exception:
+                logger.exception('PDF object does not exist')
+                raise Exception
 
-                try:
-                    self.s3_manager.client.head_object(Bucket=destination_file_bucket, Key=f'titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf')
-                    logger.exception(f'PDF already exists at key: titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf')
-                    return None
-                except Exception:
-                    logger.exception(f'PDF does not exist at key: titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf')
+            source_bucket_key = {'Bucket': pdf_bucket, 'Key': f'tagged_pdfs/{hathi_id}.pdf'}
+            try:
+                extra_args = {
+                    'ACL': 'public-read'
+                }
+                self.s3_manager.client.copy(
+                    source_bucket_key,
+                    destination_file_bucket,
+                    f'titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf',
+                    extra_args
+                )
+            except Exception:
+                logger.exception("Error during copy response")
 
-                try:
-                    pdf_bucket = os.environ["PDF_BUCKET"]
-                    self.s3_manager.client.head_object(Bucket=pdf_bucket, Key=f'tagged_pdfs/{hathi_id}.pdf')
-                except Exception:
-                    logger.exception('PDF object does not exist')
-                    raise Exception
-                
-                source_bucket_key = {'Bucket': pdf_bucket, 'Key': f'tagged_pdfs/{hathi_id}.pdf'}
-                try:
-                    extra_args = {
-                        'ACL': 'public-read'
-                    }
-                    self.s3_manager.client.copy(
-                        source_bucket_key,
-                        destination_file_bucket,
-                        f'titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf',
-                        extra_args
-                    )
-                except Exception:
-                    logger.exception("Error during copy response")
+            return destination_pdf_url
 
-                manifest_url = get_stored_file_url(storage_name=destination_file_bucket, file_path=f'titles/publisher_backlist/Schomburg/{hathi_id}/{hathi_id}.pdf')
-                return manifest_url
-                
-            raise Exception(f'Unable to get file for {record}')
-
-        
         file_id = f'{self.drive_service.id_from_url(file_location)}'
         file_name = self.drive_service.get_file_metadata(file_id).get('name')
         file = self.drive_service.get_drive_file(file_id)
-        
+
         if not file:
             raise Exception(f'Unable to get file for: {record}')
 
@@ -264,7 +296,7 @@ class PublisherBacklistService(SourceService):
         self.s3_manager.put_object(file.getvalue(), file_path, bucket)
 
         return get_stored_file_url(storage_name=bucket, file_path=file_path)
-        
+
     def build_filter_by_formula_parameter(self, deleted=None, start_timestamp: Optional[datetime]=None) -> str:
         if deleted:
             delete_filter = urllib.parse.quote("{DRB_Deleted} = TRUE()")
@@ -286,6 +318,15 @@ class PublisherBacklistService(SourceService):
         )
 
         return f"&filterByFormula=AND(OR({is_same_date_time_filter}),{is_after_date_time_filter})),{ready_to_ingest_filter},{is_not_deleted_filter})"
+
+    @staticmethod
+    def get_hathi_id(record) -> int | None:
+        hath_identifier = next((identifier for identifier in record.identifiers if identifier.endswith('hathi')), None)
+
+        if hath_identifier is not None:
+            return hath_identifier.split('|')[0]
+
+        return None
 
     def get_publisher_backlist_records(
         self,

--- a/etl-pipeline/services/sources/publisher_backlist_service.py
+++ b/etl-pipeline/services/sources/publisher_backlist_service.py
@@ -216,7 +216,11 @@ class PublisherBacklistService(SourceService):
                         flags=str(FileFlags(cover=True)),
                     )))
 
-                self.s3_manager.store_pdf_manifest(publisher_backlist_record.record, self.file_bucket, flags=FileFlags(reader=True, nypl_login=record_permissions['requires_login']), path='publisher_backlist')
+                self.s3_manager.store_pdf_manifest(
+                    publisher_backlist_record.record, self.file_bucket,
+                    flags=FileFlags(reader=True, nypl_login=record_permissions['requires_login']),
+                    path='publisher_backlist',
+                )
                 mapped_records.append(publisher_backlist_record)
             except Exception:
                 logger.exception(


### PR DESCRIPTION
## Describe your changes

Add a simple class that takes a stream of PDF data and generates a cover image, and use it in the publisher_backlist ingest to extract and store covers in S3, and add a has_part entry to the record that later gets attached to the edition during clustering.  See commits for some more detail

https://newyorkpubliclibrary.atlassian.net/browse/SFR-2559
## How to test

Download a Schomburg PDF from the drb-files-qa bucket (in this example, hvd.32044041891367.pdf) and then upload it to localstack:
```
$ aws s3 cp ~/Downloads/hvd.32044041891367.pdf s3://drb-files-local/titles/publisher_backlist/Schomburg/hvd.32044041891367/hvd.32044041891367.pdf --endpoint-url=http://localhost:4566
```
Run the publisher backlist process:
```
$ python -m main -p PublisherBacklistProcess -e local -i complete
```

Run the classify process:
```
$ python -m main -p ClassifyProcess -e local -i complete
```
Run the cluster process:
```
$ python -m main -p ClusterProcess -e local -i complete
```
Grab the generated work uuid from the works table:
```
SELECT * FROM works;
```

Fetch the OPDS publication for that work using the uuid: http://localhost:5050/opds/publication/73a18ccb-2775-424c-850c-3c3c70668acb

And observe the cover image in the `images` field under both the edition and at the top level:
```JSON
{
  "editions": [
    {
      "editions": [],
      "images": [
        {
          "href": "localhost:4566/drb-files-local/covers/publisher_backlist/hathi_hvd.32044041891367.png",
          "type": "image/png"
        }
      ],
      "links": [
        {
          "href": "https://drb-qa.nypl.org/read/2",
          "identifier": "readable",
          "rel": "http://opds-spec.org/acquisition/open-access",
          "type": "application/webpub+json"
        },
        {
          "href": "localhost:4566/drb-files-local/titles/publisher_backlist/Schomburg/hvd.32044041891367/hvd.32044041891367.pdf",
          "identifier": "downloadable",
          "rel": "http://opds-spec.org/acquisition/open-access",
          "type": "application/pdf"
        }
      ],
      "metadata": {
        "@type": "http://schema.org/Book",
        "alternate": [],
        "created": "Wed, 09 Apr 2025 16:50:03 GMT",
        "creator": "Stanley, Henry M. 1841-1904.",
        "description": null,
        "language": "",
        "locationCreated": null,
        "modified": "Wed, 09 Apr 2025 16:50:03 GMT",
        "published": "",
        "publisher": "University Libraries",
        "rights": {
          "license": "public_domain",
          "rightsStatement": "Public Domain",
          "source": "SCH Collection/Hathi files"
        },
        "sortAs": "in darkest africa, or, the quest, rescue, and retreat of emin, governor of equatoria / by henry m. stanley",
        "subtitle": null,
        "title": "In darkest Africa, or, The quest, rescue, and retreat of Emin, governor of Equatoria / by Henry M. Stanley"
      },
      "type": "application/opds-publication+json"
    }
  ],
  "images": [
    {
      "href": "localhost:4566/drb-files-local/covers/publisher_backlist/hathi_hvd.32044041891367.png",
      "type": "image/png"
    }
  ],
  "links": [
    {
      "href": "/opds/publication/73a18ccb-2775-424c-850c-3c3c70668acb",
      "rel": "self",
      "type": "application/opds-publication+json"
    },
    {
      "href": "localhost:4566/drb-files-local/manifests/publisher_backlist/SCH Collection/Hathi files/recaM2xWecnKodSSu.json",
      "rel": "http://opds-spec.org/acquisition/open-access",
      "type": "application/webpub+json"
    },
    {
      "href": "/opds/search{?query,title,subject,author}",
      "rel": "search",
      "templated": true,
      "type": "application/opds+json"
    }
  ],
  "metadata": {
    "@type": "http://schema.org/Book",
    "_meta": {},
    "alternate": [],
    "author": "Stanley, Henry M. 1841-1904.",
    "created": "Wed, 09 Apr 2025 16:50:03 GMT",
    "language": "",
    "modified": "Wed, 09 Apr 2025 16:50:03 GMT",
    "sortAs": "in darkest africa, or, the quest, rescue, and retreat of emin, governor of equatoria / by henry m. stanley",
    "subject": "",
    "subtitle": null,
    "title": "In darkest Africa, or, The quest, rescue, and retreat of Emin, governor of Equatoria / by Henry M. Stanley"
  },
  "type": "application/opds-publication+json"
}

```
