### PR TITLE
NO-REF: Fix collections load time

### DIFF
--- a/etl-pipeline/api/blueprints/drbCollection.py
+++ b/etl-pipeline/api/blueprints/drbCollection.py
@@ -409,17 +409,16 @@ def get_collections():
             uuid = collection.uuid
             path = '/collection/{}'.format(uuid)
 
-            group = constructOPDSFeed(collection, db_client, perPage=5, path=path)
+            group = constructOPDSFeed(collection, db_client, perPage=5, path=path, build_publications=False)
 
             opds_feed.addGroup(group)
-
-        db_client.closeSession()
-        logger.info('Closed db session when querying collections')
 
         return APIUtils.formatOPDS2Object(200, opds_feed)
     except Exception:
         logger.exception('Unable to get collections')
         return APIUtils.formatResponseObject(500, response_type, { 'message': 'Unable to get collections' })
+    finally:
+        db_client.closeSession()
 
 
 def constructSortMethod(sort):
@@ -442,7 +441,7 @@ def constructSortMethod(sort):
 
 
 def constructOPDSFeed(
-    collection, dbClient, sort=None, page=1, perPage=10, path=None
+    collection, dbClient, sort=None, page=1, perPage=10, path=None, build_publications: bool=True
 ):
     uuid = collection.uuid
 
@@ -462,13 +461,16 @@ def constructOPDSFeed(
         'rel': 'self', 'href': path, 'type': 'application/opds+json'
     })
 
-    if collection.type == "static":
-        _addStaticPubsToFeed(opdsFeed, collection, path, page, perPage, sort)
-    elif collection.type == "automatic":
-        esClient = ElasticClient(current_app.config["REDIS_CLIENT"])
-        _addAutomaticPubsToFeed(opdsFeed, dbClient, esClient, collection.id, path, page, perPage)
+    if build_publications:
+        if collection.type == "static":
+            _addStaticPubsToFeed(opdsFeed, collection, path, page, perPage, sort)
+        elif collection.type == "automatic":
+            esClient = ElasticClient(current_app.config["REDIS_CLIENT"])
+            _addAutomaticPubsToFeed(opdsFeed, dbClient, esClient, collection.id, path, page, perPage)
+        else:
+            raise ValueError(f"Encountered collection with unhandleable type {collection.type}")
     else:
-        raise ValueError(f"Encountered collection with unhandleable type {collection.type}")
+        opdsFeed.metadata.addField('numberOfItems', len(collection.editions))
 
     return opdsFeed
 

--- a/etl-pipeline/tests/unit/test_api_collection_blueprint.py
+++ b/etl-pipeline/tests/unit/test_api_collection_blueprint.py
@@ -772,10 +772,10 @@ class TestCollectionBlueprint:
 
             mockConstruct.assert_has_calls([
                 mocker.call(
-                    collection1, mock_db, perPage=5, path='/collection/uuid1'
+                    collection1, mock_db, perPage=5, path='/collection/uuid1', build_publications=False
                 ),
                 mocker.call(
-                    collection2, mock_db, perPage=5, path='/collection/uuid2'
+                    collection2, mock_db, perPage=5, path='/collection/uuid2', build_publications=False
                 )
             ])
 


### PR DESCRIPTION
## Describe your changes
- Since the frontend doesn't necessarily use the publications in the OPDS2 feed on the home page, we want to skip building the publications
- The collections query itself doesn't take too long but building out the publications does take a while
- The GET collections endpoint given a uuid will still build the publications and takes a long time, so we should still shoot to improve performance

## How to test
`npm run dev; python main.py -m APIProcess -e local-qa
