### PR TITLE
Eager load work and ids in collections queries

### DIFF
--- a/etl-pipeline/api/db.py
+++ b/etl-pipeline/api/db.py
@@ -185,36 +185,39 @@ class DBClient():
         return (baseQuery.count(), baseQuery.offset(offset).limit(size).all())
 
     def fetchSingleCollection(self, uuid):
-        return (
-            self.session.query(Collection)
-                .options(
-                    joinedload(Collection.editions),
-                    joinedload(Collection.editions, Edition.links),
-                    joinedload(Collection.editions, Edition.items),
-                    joinedload(Collection.editions, Edition.items, Item.links),
-                    joinedload(Collection.editions, Edition.items, Item.rights),
-                )
-                .filter(Collection.uuid == uuid).one()
-        )
+        return self._query_collections().filter(Collection.uuid == uuid).one()
 
     def fetchCollections(self, sort=None, page=1, perPage=10):
         offset = (page - 1) * perPage
 
-        sort = sort.replace(':', ' ') if sort else 'title'
+        # The `sort` param is either `title` or `creator`, optionally with a sort direction
+        # of `asc` or `desc` appended with a colon.  However, we can't just pass a plain
+        # string to sqlalchemy, as the `title` field is ambiguous across different entities.
+        # So instead, turn the sort field into a proper sort-clause on the Collection table.
+        sort_field, *suffix = sort.split(":")
+        sort_clause = getattr(Collection, sort_field)
+        if suffix and suffix[0] == "desc":
+            sort_clause = sort_clause.desc()
 
+        return (
+            self._query_collections()
+            .order_by(sort_clause)
+            .offset(offset)
+            .limit(perPage)
+            .all()
+        )
+
+    def _query_collections(self):
         return (
             self.session.query(Collection)
                 .options(
-                    joinedload(Collection.editions),
+                    joinedload(Collection.editions).joinedload(Edition.work),
                     joinedload(Collection.editions, Edition.links),
+                    joinedload(Collection.editions, Edition.identifiers),
                     joinedload(Collection.editions, Edition.items),
                     joinedload(Collection.editions, Edition.items, Item.links),
                     joinedload(Collection.editions, Edition.items, Item.rights),
                 )
-                .order_by(text(sort))
-                .offset(offset)
-                .limit(perPage)
-                .all()
         )
 
     def fetchAutomaticCollection(self, collection_id: int):


### PR DESCRIPTION
## Describe your changes
Looking at some of the slowness in newrelic, noticed that we're issuing 500 work queries and 500 identifier queries per request, due to fetching works and ids for each edition in every collection.

To alleviate this, just fetch everything upfront, using `joinedload` as we do for other entities.  I did a bit of refactoring to make both collection queries (ie, a feed vs a single colleciton) use the same base query.  I also had to add a bit of sauce to make sorting work, as the addition of work join caused column name ambiguity in the sort we were doing.

## How to test
I basically just loaded a the drb site locally and logged the query that was issued by the server to inspect that we're loading everything upfront.
