### PR TITLE
Resize PDF cover images

### DIFF
--- a/etl-pipeline/digital_assets/cover_images.py
+++ b/etl-pipeline/digital_assets/cover_images.py
@@ -1,0 +1,20 @@
+import PIL
+
+
+def resize_image_for_cover(image: PIL.Image) -> PIL.Image:
+
+    original_width = image.width
+    original_height = image.height
+    original_ratio = image.width / image.height
+
+    resize_height = 400
+    resize_width = 300
+
+    if 400 * original_ratio > 300 and original_ratio > 1:
+        resize_height = int(round(300 / original_ratio))
+    elif 400 * original_ratio > 300:
+        resize_height = int(round(300 * original_ratio))
+    else:
+        resize_width = int(round(400 * original_ratio))
+
+    return image.resize((resize_width, resize_height))

--- a/etl-pipeline/managers/cover_manager.py
+++ b/etl-pipeline/managers/cover_manager.py
@@ -2,6 +2,7 @@ import inspect
 from io import BytesIO
 from PIL import Image, UnidentifiedImageError
 
+import digital_assets.cover_images as cover_images
 import managers.cover_fetchers as fetchers
 
 
@@ -28,7 +29,7 @@ class CoverManager:
     def fetch_cover(self):
         for fetcher in self.fetchers:
             fetcher = fetcher(self.identifiers, self.db_session)
-            
+
             if fetcher.has_cover() is True:
                 self.fetcher = fetcher
                 return True
@@ -45,19 +46,7 @@ class CoverManager:
             self.cover_content = None
             return None
 
-        original_ratio = original.width / original.height
-
-        resize_height = 400
-        resize_width = 300
-
-        if 400 * original_ratio > 300 and original_ratio > 1:
-            resize_height = int(round(300 / original_ratio))
-        elif 400 * original_ratio > 300:
-            resize_height = int(round(300 * original_ratio))
-        else:
-            resize_width = int(round(400 * original_ratio))
-
-        resized = original.resize((resize_width, resize_height))
+        resized = cover_images.resize_image_for_cover(original)
 
         resized_content = BytesIO()
         resized.save(resized_content, format=original.format)

--- a/etl-pipeline/managers/pdf_cover_generator.py
+++ b/etl-pipeline/managers/pdf_cover_generator.py
@@ -6,6 +6,7 @@ import pypdf
 import requests
 import requests.exceptions
 
+from digital_assets import cover_images
 from logger import create_log
 
 logger = create_log(__name__)
@@ -30,7 +31,8 @@ class PDFCoverGenerator:
 
     def extract_cover_content(self, outstream: io.BytesIO) -> None:
         image = self._extract_cover_image()
-        image.save(outstream, format="PNG")
+        cover = cover_images.resize_image_for_cover(image)
+        cover.save(outstream, format="PNG")
         # Move the stream pointer back to the front now that we're done writing
         outstream.seek(0)
 

--- a/etl-pipeline/scripts/resize_publisher_backlist_images.py
+++ b/etl-pipeline/scripts/resize_publisher_backlist_images.py
@@ -1,0 +1,64 @@
+import argparse
+import io
+import traceback
+
+import boto3
+import PIL
+
+from digital_assets import cover_images
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", default="")
+    args = parser.parse_args()
+    session = boto3.Session(profile_name=args.profile)
+    s3 = session.client("s3")
+    for cover in list_covers(s3):
+        key = cover["Key"]
+        print(f"Processing {key}")
+        try:
+            resize_cover(s3, cover["Key"])
+        except Exception as e:
+            print(f"Resize failed: {str(e)}")
+            traceback.print_exc()
+        else:
+            print("Resize succeeded")
+
+
+def list_covers(s3):
+    paginator = s3.get_paginator("list_objects_v2")
+    responses = paginator.paginate(
+        Bucket="drb-files-qa",
+        Prefix="covers/publisher_backlist",
+    )
+    for response in responses:
+        for cover_object in response["Contents"]:
+            yield cover_object
+
+
+def resize_cover(s3, key: str) -> None:
+    image_stream = io.BytesIO()
+    print("Downloading cover")
+    s3.download_fileobj(Bucket="drb-files-qa", Key=key, Fileobj=image_stream)
+    image = PIL.Image.open(image_stream)
+    cover = cover_images.resize_image_for_cover(image)
+    cover_stream = io.BytesIO()
+    cover.save(cover_stream, format=image.format)
+    cover_stream.seek(0)
+    print("Uploading resized cover")
+    s3.upload_fileobj(
+        Bucket="drb-files-qa", Key=key, Fileobj=cover_stream,
+        ExtraArgs={"ACL": "public-read"},
+    )
+    # While we're here, let's throw these in prod too
+    s3.copy(
+        CopySource={"Bucket": "drb-files-qa", "Key": key},
+        Bucket="drb-files-production",
+        Key=key,
+        ExtraArgs={"ACL": "public-read"},
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/etl-pipeline/services/sources/publisher_backlist_service.py
+++ b/etl-pipeline/services/sources/publisher_backlist_service.py
@@ -245,7 +245,10 @@ class PublisherBacklistService(SourceService):
             logger.info("Extracting cover")
             cover_generator.extract_cover_content(stream)
             logger.info("Uploading cover")
-            self.s3_manager.client.upload_fileobj(stream, bucket, cover_key)
+            self.s3_manager.client.upload_fileobj(
+                Fileobj=stream, Bucket=bucket, Key=cover_key,
+                ExtraArgs={"ACL": "public-read"},
+            )
 
         return get_stored_file_url(bucket, cover_key)
 


### PR DESCRIPTION
## Describe your changes
Noticed the PDF generated covers had much larger file sizes on average
than externally sourced covers. Dug a bit and saw that we're resizing
external covers in the cover manager, so extract that logic into a
separate module and use it in the new PDF cover generator.

Also adds a script to quickly do this to all the existing covers in the drb bucket, and to do a couple things
I missed while I'm here, namely, setting the covers to be public, and going ahead and copying the covers to prod.

## How to test
`python -m scripts.resize_publisher_backlist_images`
