### PR TITLE
fix: Paginate collection OPDS pubications

### DIFF
--- a/etl-pipeline/api/blueprints/drbCollection.py
+++ b/etl-pipeline/api/blueprints/drbCollection.py
@@ -284,11 +284,11 @@ def get_collection(uuid):
         page = int(request.args.get('page', 1))
         per_page = int(request.args.get('perPage', 10))
 
-        collection = db_client.fetchSingleCollection(uuid)
+        collection = db_client.fetchSingleCollection(uuid, page=page, per_page=per_page)
 
         if not collection:
             return APIUtils.formatResponseObject(404, response_type, { 'message:' f'No collection found with id {uuid}' })
-        
+
         opds_feed = constructOPDSFeed(collection, db_client, sort=sort, page=page, perPage=per_page)
 
         db_client.closeSession()

--- a/etl-pipeline/api/blueprints/drbCollection.py
+++ b/etl-pipeline/api/blueprints/drbCollection.py
@@ -284,7 +284,7 @@ def get_collection(uuid):
         page = int(request.args.get('page', 1))
         per_page = int(request.args.get('perPage', 10))
 
-        collection = db_client.fetchSingleCollection(uuid, page=page, per_page=per_page)
+        collection = db_client.fetchSingleCollection(uuid)
 
         if not collection:
             return APIUtils.formatResponseObject(404, response_type, { 'message:' f'No collection found with id {uuid}' })

--- a/etl-pipeline/api/db.py
+++ b/etl-pipeline/api/db.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta, date, timezone
 from sqlalchemy import Integer
-from sqlalchemy.orm import contains_eager, joinedload, sessionmaker
-from sqlalchemy.sql import column, func, select, text, values, True_
+from sqlalchemy.orm import joinedload, sessionmaker
+from sqlalchemy.sql import column, func, select, text, values
 from uuid import uuid4
 
-from model import COLLECTION_EDITIONS, Work, Edition, Link, Item, Record, Collection, User, AutomaticCollection
+from model import Work, Edition, Link, Item, Record, Collection, User, AutomaticCollection
 from .utils import APIUtils
 from logger import create_log
 

--- a/etl-pipeline/api/db.py
+++ b/etl-pipeline/api/db.py
@@ -6,9 +6,6 @@ from uuid import uuid4
 
 from model import Work, Edition, Link, Item, Record, Collection, User, AutomaticCollection
 from .utils import APIUtils
-from logger import create_log
-
-logger = create_log(__name__)
 
 
 class DBClient():

--- a/etl-pipeline/model/__init__.py
+++ b/etl-pipeline/model/__init__.py
@@ -7,7 +7,7 @@ from .postgres.identifier import Identifier
 from .postgres.link import Link
 from .postgres.olCover import OpenLibraryCover
 from .postgres.rights import Rights
-from .postgres.collection import Collection, AutomaticCollection, COLLECTION_EDITIONS
+from .postgres.collection import Collection, AutomaticCollection
 from .postgres.user import User
 
 from .elasticsearch.agent import Agent as ESAgent

--- a/etl-pipeline/model/__init__.py
+++ b/etl-pipeline/model/__init__.py
@@ -7,7 +7,7 @@ from .postgres.identifier import Identifier
 from .postgres.link import Link
 from .postgres.olCover import OpenLibraryCover
 from .postgres.rights import Rights
-from .postgres.collection import Collection, AutomaticCollection
+from .postgres.collection import Collection, AutomaticCollection, COLLECTION_EDITIONS
 from .postgres.user import User
 
 from .elasticsearch.agent import Agent as ESAgent

--- a/etl-pipeline/tests/unit/test_api_collection_blueprint.py
+++ b/etl-pipeline/tests/unit/test_api_collection_blueprint.py
@@ -772,10 +772,10 @@ class TestCollectionBlueprint:
 
             mockConstruct.assert_has_calls([
                 mocker.call(
-                    collection1, mock_db, perPage=5, path='/collection/uuid1', build_publications=False
+                    collection1, mock_db, perPage=5, path='/collection/uuid1'
                 ),
                 mocker.call(
-                    collection2, mock_db, perPage=5, path='/collection/uuid2', build_publications=False
+                    collection2, mock_db, perPage=5, path='/collection/uuid2'
                 )
             ])
 

--- a/etl-pipeline/tests/unit/test_api_db.py
+++ b/etl-pipeline/tests/unit/test_api_db.py
@@ -125,12 +125,6 @@ class TestDBClient:
         testInstance.session.query().options().filter().one\
             .assert_called_once()
 
-    def test_fetchCollections(self, testInstance):
-        testInstance.session.query().options().order_by().offset().limit().all\
-            .return_value = 'testCollections'
-
-        assert testInstance.fetchCollections() == 'testCollections'
-
     def test_createStaticCollection(self, testInstance, mocker):
         mockUUID = mocker.patch('api.db.uuid4')
         mockUUID.return_value = 'testUUID'


### PR DESCRIPTION
## Describe your changes
We've been fetching the collection and then later filtering with pagination params. My previous PR to eager load works and identifiers kinda made things worse, in that it led to us eager loading data for every edition, not just the filtered ones.

So, pass the pagination params into the DB method, first fetch the page of editions and then attach them to the collection object.

Id tried to do this using the orm loading strategies but couldn't really get it working, so I figured, just doing two pretty small quorm loading strategies but couldn't really get it working, so I figured, just doing two pretty small queries is fine and probably easier to understand.

## How to test
Hit the collections/{uuid} endpoint locally
