### PR TITLE
fix: Properly load covers on collection page

### DIFF
--- a/web/src/components/CollectionItemCard/CollectionItemCard.test.tsx
+++ b/web/src/components/CollectionItemCard/CollectionItemCard.test.tsx
@@ -25,7 +25,7 @@ describe("Collection Item Card", () => {
   });
   test("Shows cover", () => {
     expect(screen.getByAltText("").closest("img").src).toEqual(
-      "https://test-sfr-covers.s3.amazonaws.com/default/defaultCover.png"
+      "https://drb-files-qa.s3.amazonaws.com/covers/default/defaultCover.png"
     );
   });
   test("shows license", () => {

--- a/web/src/components/CollectionItemCard/CollectionItemCard.tsx
+++ b/web/src/components/CollectionItemCard/CollectionItemCard.tsx
@@ -29,7 +29,7 @@ export const CollectionItemCard: React.FC<{
   return (
     <Card
       imageProps={{
-        src: CollectionUtils.getCover(collectionItem),
+        src: CollectionUtils.getItemCover(collectionItem),
         fallbackSrc: PLACEHOLDER_COVER_LINK,
         size: "xsmall",
         aspectRatio: "original",

--- a/web/src/util/CollectionUtils.tsx
+++ b/web/src/util/CollectionUtils.tsx
@@ -23,6 +23,13 @@ export default class CollectionUtils {
     return coverLink ? formatUrl(coverLink.href) : PLACEHOLDER_COVER_LINK;
   }
 
+  static getItemCover(collectionItem: OpdsPublication): string {
+    const coverLink = collectionItem.images.find((link) => {
+      return MediaTypes.display.includes(link.type);
+    });
+    return coverLink ? formatUrl(coverLink.href) : PLACEHOLDER_COVER_LINK;
+  }
+
   // TODO: replace with collection_id property that will be added on backend response
   static getId(links: OpdsLink[]): string {
     if (!links || links.length === 0) return "";

--- a/web/src/util/CollectionUtils.tsx
+++ b/web/src/util/CollectionUtils.tsx
@@ -5,7 +5,7 @@ import {
   PLACEHOLDER_COVER_LINK,
 } from "~/src/constants/editioncard";
 import { MediaTypes } from "~/src/constants/mediaTypes";
-import { Opds2Feed, OpdsLink } from "~/src/types/OpdsModel";
+import { Opds2Feed, OpdsLink, OpdsPublication } from "~/src/types/OpdsModel";
 
 type ReadOnlineTypes = "readable" | "embedable";
 


### PR DESCRIPTION
## Describe your changes

Was testing some of the server side cover work I did and noticed I could get covers to load for an individual edition but not on the collection page - inspected the components and looks like we were trying to pass an OpdsPublication to a cover method that expects a full feed. Easy enough to just write a new cover finding method for a single edition.

https://newyorkpubliclibrary.atlassian.net/browse/SFR-2559

## How to test

Ran locally against the QA API and took a look at the Schomburg collection, saw that the covers are now loaded:
<img width="1389" alt="Screen Shot 2025-04-14 at 10 10 28 AM" src="https://github.com/user-attachments/assets/a1abdb7c-1d41-450a-b3ca-a85a040f4143" />



