### PR TITLE
SFR-2619: Fix publisher backlist ingest process

### DIFF
--- a/etl-pipeline/README.md
+++ b/etl-pipeline/README.md
@@ -225,4 +225,4 @@ Boolean flags used in the API:
 - `download`: Book is downloadable
 - `catalog`: Book is requestable but not readable online
 - `nypl_login`: Requestable by NYPL patrons
-- `limited_access`: Limited Access book for NYPL patrons
+- `fulfill_limited_access`: Limited Access book for NYPL patrons

--- a/etl-pipeline/main.py
+++ b/etl-pipeline/main.py
@@ -107,6 +107,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     load_env_file(args.environment, './config/{}.yaml')
-    os.environ['ENVIRONMENT'] = args.environment
+    os.environ['ENVIRONMENT'] = os.environ.get('ENVIRONMENT') or args.environment
 
     main(args)

--- a/etl-pipeline/managers/s3.py
+++ b/etl-pipeline/managers/s3.py
@@ -87,13 +87,13 @@ class S3Manager:
             object_type = mimetypes.guess_type(key)[0] or 'binary/octet-stream'
 
             return self.client.put_object(
-                ACL=bucket_permissions,
                 Body=object,
                 Bucket=bucket,
                 Key=key,
                 ContentMD5=object_md5,
                 ContentType=object_type,
-                Metadata={ 'md5Checksum': object_md5 }
+                Metadata={ 'md5Checksum': object_md5 },
+                **({ 'ACL': bucket_permissions } if bucket_permissions is not None else {})
             )
         except ClientError as e:
             raise S3Error(f'Unable to store file {key} in s3: {e}')

--- a/etl-pipeline/model/postgres/record.py
+++ b/etl-pipeline/model/postgres/record.py
@@ -76,7 +76,7 @@ class FileFlags:
     embed: bool = False
     download: bool = False
     cover: bool = False
-    limited_access: bool = False
+    fulfill_limited_access: bool = False
     nypl_login: bool = False
 
     def __str__(self):

--- a/etl-pipeline/processes/link_fulfiller.py
+++ b/etl-pipeline/processes/link_fulfiller.py
@@ -21,10 +21,8 @@ class LinkFulfiller:
 
     def fulfill_records_links(self, records: list[Record]):
         for record in records:
-            for part in record.parts:
-                if json.loads(part.flags).get('limited_access'):
-                    self._fulfill_manifest(record)
-                    logger.info(f'Fulfilled manifest links for record: {record}')
+            if any(json.loads(part.flags).get('fulfill_limited_access') for part in record.parts):
+                self._fulfill_manifest(record)
 
     def _fulfill_manifest(self, record: Record):
         manifest_part = next(filter(lambda part: part.file_type == 'application/webpub+json', record.parts), None)
@@ -46,8 +44,8 @@ class LinkFulfiller:
             Bucket=manifest_part.file_bucket, 
             Key=manifest_part.file_key, 
             Body=json.dumps(fulfilled_manifest, ensure_ascii=False), 
-            ACL= 'public-read', 
-            ContentType = 'application/json'
+            ACL='public-read', 
+            ContentType='application/json'
         )
 
     def _update_manifest_links(self, manifest_json: dict):

--- a/etl-pipeline/services/sources/publisher_backlist_service.py
+++ b/etl-pipeline/services/sources/publisher_backlist_service.py
@@ -184,9 +184,6 @@ class PublisherBacklistService(SourceService):
 
                 publisher_backlist_record = PublisherBacklistMapping(record_metadata)
                 publisher_backlist_record.applyMapping()
-
-                if publisher_backlist_record.record.source != 'UofMichigan Backlist':
-                    continue
                 
                 hathi_id = PublisherBacklistService.get_hathi_id(publisher_backlist_record.record)
 

--- a/etl-pipeline/tests/conftest.py
+++ b/etl-pipeline/tests/conftest.py
@@ -332,7 +332,7 @@ def limited_access_record_uuid(db_manager):
                 url='https://example.com/book.epub',
                 source=TEST_SOURCE,
                 file_type='application/epub+zip',
-                flags=str(FileFlags(reader=True, nypl_login=True))
+                flags=str(FileFlags(reader=True, nypl_login=True, fulfill_limited_access=True))
             )),
         ],
     }

--- a/etl-pipeline/tests/functional/processes/test_link_fulfiller.py
+++ b/etl-pipeline/tests/functional/processes/test_link_fulfiller.py
@@ -43,7 +43,7 @@ def test_fulfill_links(db_manager, s3_manager, limited_access_record_uuid):
         url=get_stored_file_url(storage_name=os.environ['FILE_BUCKET'], file_path=manifest_key),
         source=record.source,
         file_type='application/webpub+json',
-        flags=str(FileFlags(reader=True, limited_access=True))
+        flags=str(FileFlags(reader=True, nypl_login=True, fulfill_limited_access=True))
     )))
 
     link_fulfiller = LinkFulfiller(db_manager)


### PR DESCRIPTION
## Describe your changes
- Fixes saving filed to limited bucket which does not allow ACLs 
- Fixes using local-qa/local-production config where environment is set in the config
- Changes limited_access flag to fulfill_limited_access
- Updates redrive process
- Fixes publisher backlist ingest for records that do not have a hathi_id

## How to test
`make up; make functional; make integration`