### PR TITLE
Finish QA deploy before integration tests run

### DIFF
--- a/.github/workflows/etl-pipeline-deploy-qa.yaml
+++ b/.github/workflows/etl-pipeline-deploy-qa.yaml
@@ -37,3 +37,4 @@ jobs:
       - name: Force ECS Update
         run: |
           aws ecs update-service --cluster sfr-pipeline-qa-tf --service sfr-pipeline-qa-tf --force-new-deployment
+          aws ecs wait services-stable --cluster $sfr-pipeline-qa-tf--services $sfr-pipeline-qa-tf


### PR DESCRIPTION
Something I noticed the other day - we tell ECS to deploy the new image and then immediately run integration tests. However, with how ECS deployments work, it's not clear whether the tests are hitting the old or new tasks. Waiting for services to be stable will ensure we're testing against the new image and will also avoid running the tests if the new instance never becomes healthy

## Describe your changes

## How to test
