### PR TITLE
Remove ecs wait step from deploy

### DIFF
--- a/.github/workflows/etl-pipeline-deploy-qa.yaml
+++ b/.github/workflows/etl-pipeline-deploy-qa.yaml
@@ -37,4 +37,3 @@ jobs:
       - name: Force ECS Update
         run: |
           aws ecs update-service --cluster sfr-pipeline-qa-tf --service sfr-pipeline-qa-tf --force-new-deployment
-          aws ecs wait services-stable --cluster sfr-pipeline-qa-tf --services sfr-pipeline-qa-tf


### PR DESCRIPTION
Sigh, *something* is preventing this from working, maybe some kind of memory issue that makes ECS take forever to come alive?  I created https://newyorkpubliclibrary.atlassian.net/browse/SFR-2634 to investigate further.

## Describe your changes

## How to test
