### PR TITLE
Decouple RecordIngestor from SourceService

### DIFF
--- a/etl-pipeline/processes/ingest/chicago_isac.py
+++ b/etl-pipeline/processes/ingest/chicago_isac.py
@@ -13,7 +13,8 @@ class ChicagoISACProcess():
 
     def runProcess(self):
         start_timestamp = utils.get_start_datetime(
-            process_type=self.params.process_type, ingest_period=self.params.ingest_period,
+            process_type=self.params.process_type,
+            ingest_period=self.params.ingest_period,
         ),
         return self.record_ingestor.ingest(
             self.chicago_isac_service.get_records(

--- a/etl-pipeline/processes/ingest/chicago_isac.py
+++ b/etl-pipeline/processes/ingest/chicago_isac.py
@@ -13,12 +13,12 @@ class ChicagoISACProcess():
 
     def runProcess(self):
         start_timestamp = utils.get_start_datetime(
-            process_type=params.process_type, ingest_period=params.ingest_period,
+            process_type=self.params.process_type, ingest_period=self.params.ingest_period,
         ),
         return self.record_ingestor.ingest(
-            self.chicago_isac_process.get_records(
+            self.chicago_isac_service.get_records(
                 start_timestamp=start_timestamp,
-                offset=params.offset,
-                limit=params.limit,
+                offset=self.params.offset,
+                limit=self.params.limit,
             ),
         )

--- a/etl-pipeline/processes/ingest/chicago_isac.py
+++ b/etl-pipeline/processes/ingest/chicago_isac.py
@@ -9,7 +9,16 @@ class ChicagoISACProcess():
     def __init__(self, *args):
         self.chicago_isac_service = ChicagoISACService()
         self.params = utils.parse_process_args(*args)
-        self.record_ingestor = RecordIngestor(source_service=self.chicago_isac_service, source=Source.CHICACO_ISAC.value)
+        self.record_ingestor = RecordIngestor(source=Source.CHICACO_ISAC.value)
 
-    def runProcess(self):    
-        return self.record_ingestor.ingest(params=self.params)
+    def runProcess(self):
+        start_timestamp = utils.get_start_datetime(
+            process_type=params.process_type, ingest_period=params.ingest_period,
+        ),
+        return self.record_ingestor.ingest(
+            self.chicago_isac_process.get_records(
+                start_timestamp=start_timestamp,
+                offset=params.offset,
+                limit=params.limit,
+            ),
+        )

--- a/etl-pipeline/processes/ingest/clacso.py
+++ b/etl-pipeline/processes/ingest/clacso.py
@@ -18,7 +18,8 @@ class CLACSOProcess():
 
     def runProcess(self):
         start_timestamp = utils.get_start_datetime(
-            process_type=self.params.process_type, ingest_period=self.params.ingest_period,
+            process_type=self.params.process_type,
+            ingest_period=self.params.ingest_period,
         ),
         return self.record_ingestor.ingest(
             self.dspace_service.get_records(

--- a/etl-pipeline/processes/ingest/clacso.py
+++ b/etl-pipeline/processes/ingest/clacso.py
@@ -18,12 +18,12 @@ class CLACSOProcess():
 
     def runProcess(self):
         start_timestamp = utils.get_start_datetime(
-            process_type=params.process_type, ingest_period=params.ingest_period,
+            process_type=self.params.process_type, ingest_period=self.params.ingest_period,
         ),
         return self.record_ingestor.ingest(
-            self.dspace.get_records(
+            self.dspace_service.get_records(
                 start_timestamp=start_timestamp,
-                offset=params.offset,
-                limit=params.limit,
+                offset=self.params.offset,
+                limit=self.params.limit,
             ),
         )

--- a/etl-pipeline/processes/ingest/clacso.py
+++ b/etl-pipeline/processes/ingest/clacso.py
@@ -14,7 +14,16 @@ class CLACSOProcess():
     def __init__(self, *args):
         self.dspace_service = DSpaceService(base_url=self.CLACSO_BASE_URL, source_mapping=CLACSOMapping)
         self.params = utils.parse_process_args(*args)
-        self.record_ingestor = RecordIngestor(source_service=self.dspace_service, source=Source.CLACSO.value)
+        self.record_ingestor = RecordIngestor(source=Source.CLACSO.value)
 
-    def runProcess(self):    
-        return self.record_ingestor.ingest(params=self.params)
+    def runProcess(self):
+        start_timestamp = utils.get_start_datetime(
+            process_type=params.process_type, ingest_period=params.ingest_period,
+        ),
+        return self.record_ingestor.ingest(
+            self.dspace.get_records(
+                start_timestamp=start_timestamp,
+                offset=params.offset,
+                limit=params.limit,
+            ),
+        )

--- a/etl-pipeline/processes/ingest/hathi_trust.py
+++ b/etl-pipeline/processes/ingest/hathi_trust.py
@@ -14,7 +14,8 @@ class HathiTrustProcess():
 
     def runProcess(self) -> int:
         start_timestamp = utils.get_start_datetime(
-            process_type=self.params.process_type, ingest_period=self.params.ingest_period,
+            process_type=self.params.process_type,
+            ingest_period=self.params.ingest_period,
         ),
         return self.record_ingestor.ingest(
             self.hathi_trust_service.get_records(

--- a/etl-pipeline/processes/ingest/hathi_trust.py
+++ b/etl-pipeline/processes/ingest/hathi_trust.py
@@ -10,7 +10,16 @@ class HathiTrustProcess():
     def __init__(self, *args):
         self.hathi_trust_service = HathiTrustService()
         self.params = utils.parse_process_args(*args)
-        self.record_ingestor = RecordIngestor(source_service=self.hathi_trust_service, source=Source.HATHI.value)
+        self.record_ingestor = RecordIngestor(source=Source.HATHI.value)
 
     def runProcess(self) -> int:
-        return self.record_ingestor.ingest(params=self.params)
+        start_timestamp = utils.get_start_datetime(
+            process_type=params.process_type, ingest_period=params.ingest_period,
+        ),
+        return self.record_ingestor.ingest(
+            self.hathi_trust_service.get_records(
+                start_timestamp=start_timestamp,
+                offset=params.offset,
+                limit=params.limit,
+            ),
+        )

--- a/etl-pipeline/processes/ingest/hathi_trust.py
+++ b/etl-pipeline/processes/ingest/hathi_trust.py
@@ -14,12 +14,12 @@ class HathiTrustProcess():
 
     def runProcess(self) -> int:
         start_timestamp = utils.get_start_datetime(
-            process_type=params.process_type, ingest_period=params.ingest_period,
+            process_type=self.params.process_type, ingest_period=self.params.ingest_period,
         ),
         return self.record_ingestor.ingest(
             self.hathi_trust_service.get_records(
                 start_timestamp=start_timestamp,
-                offset=params.offset,
-                limit=params.limit,
+                offset=self.params.offset,
+                limit=self.params.limit,
             ),
         )

--- a/etl-pipeline/processes/ingest/met.py
+++ b/etl-pipeline/processes/ingest/met.py
@@ -10,7 +10,16 @@ class METProcess():
     def __init__(self, *args):
         self.met_service = METService()
         self.params = utils.parse_process_args(*args)
-        self.record_ingestor = RecordIngestor(source_service=self.met_service, source=Source.MET.value)
+        self.record_ingestor = RecordIngestor(source=Source.MET.value)
 
     def runProcess(self) -> int:
-        return self.record_ingestor.ingest(params=self.params)
+        start_timestamp = utils.get_start_datetime(
+            process_type=params.process_type, ingest_period=params.ingest_period,
+        ),
+        return self.record_ingestor.ingest(
+            self.met_service.get_records(
+                start_timestamp=start_timestamp,
+                offset=params.offset,
+                limit=params.limit,
+            ),
+        )

--- a/etl-pipeline/processes/ingest/met.py
+++ b/etl-pipeline/processes/ingest/met.py
@@ -14,7 +14,8 @@ class METProcess():
 
     def runProcess(self) -> int:
         start_timestamp = utils.get_start_datetime(
-            process_type=self.params.process_type, ingest_period=self.params.ingest_period,
+            process_type=self.params.process_type,
+            ingest_period=self.params.ingest_period,
         ),
         return self.record_ingestor.ingest(
             self.met_service.get_records(

--- a/etl-pipeline/processes/ingest/met.py
+++ b/etl-pipeline/processes/ingest/met.py
@@ -14,12 +14,12 @@ class METProcess():
 
     def runProcess(self) -> int:
         start_timestamp = utils.get_start_datetime(
-            process_type=params.process_type, ingest_period=params.ingest_period,
+            process_type=self.params.process_type, ingest_period=self.params.ingest_period,
         ),
         return self.record_ingestor.ingest(
             self.met_service.get_records(
                 start_timestamp=start_timestamp,
-                offset=params.offset,
-                limit=params.limit,
+                offset=self.params.offset,
+                limit=self.params.limit,
             ),
         )

--- a/etl-pipeline/processes/ingest/nypl.py
+++ b/etl-pipeline/processes/ingest/nypl.py
@@ -15,7 +15,8 @@ class NYPLProcess():
 
     def runProcess(self):
         start_timestamp = utils.get_start_datetime(
-            process_type=self.params.process_type, ingest_period=self.params.ingest_period,
+            process_type=self.params.process_type,
+            ingest_period=self.params.ingest_period,
         ),
         return self.record_ingestor.ingest(
             self.nypl_bib_service.get_records(

--- a/etl-pipeline/processes/ingest/nypl.py
+++ b/etl-pipeline/processes/ingest/nypl.py
@@ -11,7 +11,16 @@ class NYPLProcess():
     def __init__(self, *args):
         self.nypl_bib_service = NYPLBibService()
         self.params = utils.parse_process_args(*args)
-        self.record_ingestor = RecordIngestor(source_service=self.nypl_bib_service, source=Source.NYPL.value)
+        self.record_ingestor = RecordIngestor(source=Source.NYPL.value)
 
-    def runProcess(self):    
-        return self.record_ingestor.ingest(params=self.params)
+    def runProcess(self):
+        start_timestamp = utils.get_start_datetime(
+            process_type=params.process_type, ingest_period=params.ingest_period,
+        ),
+        return self.record_ingestor.ingest(
+            self.nypl_bib_service.get_records(
+                start_timestamp=start_timestamp,
+                offset=params.offset,
+                limit=params.limit,
+            ),
+        )

--- a/etl-pipeline/processes/ingest/nypl.py
+++ b/etl-pipeline/processes/ingest/nypl.py
@@ -15,12 +15,12 @@ class NYPLProcess():
 
     def runProcess(self):
         start_timestamp = utils.get_start_datetime(
-            process_type=params.process_type, ingest_period=params.ingest_period,
+            process_type=self.params.process_type, ingest_period=self.params.ingest_period,
         ),
         return self.record_ingestor.ingest(
             self.nypl_bib_service.get_records(
                 start_timestamp=start_timestamp,
-                offset=params.offset,
-                limit=params.limit,
+                offset=self.params.offset,
+                limit=self.params.limit,
             ),
         )

--- a/etl-pipeline/processes/record_ingestor.py
+++ b/etl-pipeline/processes/record_ingestor.py
@@ -13,7 +13,7 @@ logger = create_log(__name__)
 
 class RecordIngestor:
 
-    def __init__(self, source_service: SourceService, source: str):
+    def __init__(self, source: str):
         self.source = source
 
         self.records_queue = os.environ['RECORD_PIPELINE_QUEUE']

--- a/etl-pipeline/processes/record_ingestor.py
+++ b/etl-pipeline/processes/record_ingestor.py
@@ -1,8 +1,10 @@
 import json
 import os
+import typing
 
 from logger import create_log
 from managers import RabbitMQManager
+from model import Record
 from services.sources.source_service import SourceService
 from . import utils
 
@@ -13,25 +15,18 @@ class RecordIngestor:
 
     def __init__(self, source_service: SourceService, source: str):
         self.source = source
-        self.source_service = source_service
 
         self.records_queue = os.environ['RECORD_PIPELINE_QUEUE']
         self.records_route = os.environ['RECORD_PIPELINE_ROUTING_KEY']
-        
+
         self.queue_mananger = RabbitMQManager()
         self.queue_mananger.create_connection()
         self.queue_mananger.create_or_connect_queue(self.records_queue, self.records_route)
 
-    def ingest(self, params: utils.ProcessParams) -> int:
+    def ingest(self, records: typing.Iterator[Record]) -> int:
         ingest_count = 0
 
         try:
-            records = self.source_service.get_records(
-                start_timestamp=utils.get_start_datetime(process_type=params.process_type, ingest_period=params.ingest_period),
-                offset=params.offset,
-                limit=params.limit
-            )
-
             for record in records:
                 self.queue_mananger.send_message_to_queue(
                     queue_name=self.records_queue,

--- a/etl-pipeline/tests/functional/processes/frbr/test_record_pipeline.py
+++ b/etl-pipeline/tests/functional/processes/frbr/test_record_pipeline.py
@@ -25,7 +25,7 @@ def test_record_pipeline(db_manager, rabbitmq_manager: RabbitMQManager, unfrbriz
         message=json.dumps(record.to_dict(), default=str)
     )
 
-    sleep(1)
+    sleep(2)
 
     record_pipeline.runProcess(max_attempts=1)
     db_manager.session.refresh(record)

--- a/etl-pipeline/tests/functional/processes/frbr/test_record_pipeline.py
+++ b/etl-pipeline/tests/functional/processes/frbr/test_record_pipeline.py
@@ -25,9 +25,9 @@ def test_record_pipeline(db_manager, rabbitmq_manager: RabbitMQManager, unfrbriz
         message=json.dumps(record.to_dict(), default=str)
     )
 
-    sleep(5)
+    sleep(1)
 
-    record_pipeline.runProcess(max_attempts=1)
+    record_pipeline.runProcess(max_attempts=4)
     db_manager.session.refresh(record)
 
     assert_record_frbrized(record_uuid=unfrbrized_pipeline_record_uuid, db_manager=db_manager)

--- a/etl-pipeline/tests/functional/processes/frbr/test_record_pipeline.py
+++ b/etl-pipeline/tests/functional/processes/frbr/test_record_pipeline.py
@@ -25,7 +25,7 @@ def test_record_pipeline(db_manager, rabbitmq_manager: RabbitMQManager, unfrbriz
         message=json.dumps(record.to_dict(), default=str)
     )
 
-    sleep(2)
+    sleep(5)
 
     record_pipeline.runProcess(max_attempts=1)
     db_manager.session.refresh(record)


### PR DESCRIPTION
## Describe your changes

Some ingests have custom manifest logic, and future ingest processes might have more custom processing. So decouple the source service from the ingestor, instead simply passing a (usually lazy) collection of records to the ingestor, allowing the ingest process to do any special processing of records before handing them off to the ingestor.

For now, the changes in this PR are boilerplate, since we haven't transitioned any of the special ingests to the record ingestor



## How to test
