### PR TITLE
SFR-2619: Extract deletion logic from publisher backlist ingest

### DIFF
--- a/etl-pipeline/processes/__init__.py
+++ b/etl-pipeline/processes/__init__.py
@@ -23,6 +23,7 @@ from .ingest.clacso import CLACSOProcess
 from .record_ingestor import RecordIngestor
 from .link_fulfiller import LinkFulfiller
 from .record_frbrizer import RecordFRBRizer
+from .record_deleter import RecordDeleter
 from .record_file_saver import RecordFileSaver
 from .record_clusterer import RecordClusterer
-from .record_pipeline.record_pipeline import RecordPipelineProcess
+from .record_pipeline import RecordPipelineProcess

--- a/etl-pipeline/processes/__init__.py
+++ b/etl-pipeline/processes/__init__.py
@@ -25,4 +25,4 @@ from .link_fulfiller import LinkFulfiller
 from .record_frbrizer import RecordFRBRizer
 from .record_file_saver import RecordFileSaver
 from .record_clusterer import RecordClusterer
-from .record_pipeline import RecordPipelineProcess
+from .record_pipeline.record_pipeline import RecordPipelineProcess

--- a/etl-pipeline/processes/record_deleter.py
+++ b/etl-pipeline/processes/record_deleter.py
@@ -1,0 +1,102 @@
+import os
+from sqlalchemy import joinedload
+
+from logger import create_log
+from model import Edition, Item, Record, Work
+from managers import DBManager, ElasticsearchManager, S3Manager
+
+logger = create_log(__name__)
+
+
+class RecordDeleter:
+
+    def __init__(self, db_manager: DBManager, store_manager: S3Manager, es_manager: ElasticsearchManager):
+        self.db_manager = db_manager
+        self.store_manager = store_manager
+        self.es_manager = es_manager
+
+    def delete_record(self, record: Record):
+        self._delete_record_digital_assets(record)
+        self._delete_record(record)
+
+        logger.info(f'Deleted {record}')
+
+    def _delete_record(self, record: Record):
+        items = (
+            self.db_manager.session.query(Item)
+            .filter(Item.record_id == record.id)
+            .all()
+        )
+        edition_ids = set([item.edition_id for item in items])
+
+        self.db_manager.session.delete(record)
+
+        for item in items:
+            self.db_manager.session.delete(item)
+
+        self.db_manager.session.commit()
+
+        deleted_edition_ids = {}
+        deleted_work_ids = set()
+        work_ids = set()
+        work_ids_to_uuids = {}
+
+        for edition_id in edition_ids:
+            edition = (
+                self.db_manager.session.query(Edition)
+                .options(joinedload(Edition.items))
+                .filter(Edition.id == edition_id)
+                .first()
+            )
+
+            if edition and not edition.items:
+                self.db_manager.session.delete(edition)
+
+                work_ids.add(edition.work_id)
+                deleted_edition_ids[edition_id] = edition.work_id
+
+        self.db_manager.session.commit()
+
+        for work_id in work_ids:
+            work = (
+                self.db_manager.session.query(Work)
+                .options(joinedload(Work.editions))
+                .filter(Work.id == work_id)
+                .first()
+            )
+            work_ids_to_uuids[work.id] = work.uuid
+
+            if work and not work.editions:
+                self.db_manager.session.delete(work)
+
+                self.es_manager.client.delete(
+                    index=os.environ["ELASTICSEARCH_INDEX"], id=work.uuid
+                )
+
+                deleted_work_ids.add(work_id)
+
+        self.db_manager.session.commit()
+
+        for edition_id, work_id in deleted_edition_ids.items():
+            if work_id not in deleted_work_ids:
+                work_uuid = work_ids_to_uuids[work_id]
+                work_document = self.es_manager.client.get(
+                    index=os.environ["ELASTICSEARCH_INDEX"], id=work_uuid
+                )
+                editions = work_document["_source"].get("editions", [])
+
+                updated_editions = [
+                    edition for edition in editions if edition.get("id") != edition_id
+                ]
+                work_document["_source"]["editions"] = updated_editions
+
+                self.es_manager.client.index(
+                    index=os.environ["ELASTICSEARCH_INDEX"],
+                    id=work_uuid,
+                    body=work_document["_source"],
+                )
+
+    def _delete_record_digital_assets(self, record: Record):
+        for part in record.parts:
+            if part.file_bucket and part.file_key:
+                self.store_manager.client.delete_object(Bucket=part.file_bucket, Key=part.file_key)

--- a/etl-pipeline/processes/record_pipeline.py
+++ b/etl-pipeline/processes/record_pipeline.py
@@ -4,11 +4,12 @@ from time import sleep
 
 from .record_frbrizer import RecordFRBRizer
 from .record_clusterer import RecordClusterer
+from .record_deleter import RecordDeleter
 from .record_file_saver import RecordFileSaver
 from .link_fulfiller import LinkFulfiller
 
 from logger import create_log
-from managers import DBManager, RabbitMQManager, S3Manager
+from managers import DBManager, ElasticsearchManager, RabbitMQManager, S3Manager
 from model import Record
 
 logger = create_log(__name__)
@@ -28,10 +29,14 @@ class RecordPipelineProcess:
 
         self.storage_manager = S3Manager()
 
+        self.es_manager = ElasticsearchManager()
+        self.es_manager.create_elastic_connection()
+
         self.record_file_saver = RecordFileSaver(storage_manager=self.storage_manager)
         self.record_frbrizer = RecordFRBRizer(db_manager=self.db_manager)
         self.record_clusterer = RecordClusterer(db_manager=self.db_manager)
         self.link_fulfiller = LinkFulfiller(db_manager=self.db_manager)
+        self.record_deleter = RecordDeleter(db_manager=self.db_manager, store_manager=self.storage_manager, es_manager=self.es_manager)
 
     def runProcess(self, max_attempts: int=4):
         try:
@@ -63,11 +68,14 @@ class RecordPipelineProcess:
 
             self.db_manager.create_session()
 
-            self.record_file_saver.save_record_files(record)
-            saved_record = self._save_record(record)
-            frbrized_record = self.record_frbrizer.frbrize_record(saved_record)
-            clustered_records = self.record_clusterer.cluster_record(frbrized_record)
-            self.link_fulfiller.fulfill_records_links(clustered_records)
+            if record._deletion_flag is True:
+                self.record_deleter.delete_record(record)
+            else:
+                self.record_file_saver.save_record_files(record)
+                saved_record = self._save_record(record)
+                frbrized_record = self.record_frbrizer.frbrize_record(saved_record)
+                clustered_records = self.record_clusterer.cluster_record(frbrized_record)
+                self.link_fulfiller.fulfill_records_links(clustered_records)
                 
             self.queue_manager.acknowledge_message_processed(message_props.delivery_tag)
         except Exception:


### PR DESCRIPTION
## Describe your changes
- Moves the deletion logic from publisher backlist ingest to a record deleter
- The record deleter delete_record function is called when the deletion flag on a record is true
- Still need to add a test
- Will add the deleted record retrieval back in after migrating out the rest of the logic 

## How to test
`make up; make functional; make integration`