### PR TITLE
Use read replica for API

### DIFF
--- a/etl-pipeline/api/blueprints/drbCollection.py
+++ b/etl-pipeline/api/blueprints/drbCollection.py
@@ -70,6 +70,7 @@ def collectionCreate(user=None):
     if errMsg:
         return APIUtils.formatResponseObject(400, 'createCollection', {'message': errMsg})
 
+    # TODO: Connect to write client: https://newyorkpubliclibrary.atlassian.net/browse/SFR-2668
     dbClient = DBClient(current_app.config['DB_CLIENT'])
     dbClient.createSession()
 
@@ -162,6 +163,7 @@ def collectionReplace(uuid, user=None):
 
         return APIUtils.formatResponseObject(400, 'createCollection', errMsg)
 
+    # TODO: Connect to write client: https://newyorkpubliclibrary.atlassian.net/browse/SFR-2668
     dbClient = DBClient(current_app.config['DB_CLIENT'])
     dbClient.createSession()
 
@@ -202,6 +204,7 @@ def collectionReplace(uuid, user=None):
 def collectionUpdate(uuid, user=None):
     logger.info('Handling collection update request')
 
+    # TODO: Connect to write client: https://newyorkpubliclibrary.atlassian.net/browse/SFR-2668
     dbClient = DBClient(current_app.config['DB_CLIENT'])
     dbClient.createSession()
 
@@ -307,6 +310,7 @@ def get_collection(uuid):
 def collectionDelete(uuid, user=None):
     logger.info('Deleting collection {}'.format(uuid))
 
+    # TODO: Connect to write client: https://newyorkpubliclibrary.atlassian.net/browse/SFR-2668
     dbClient = DBClient(current_app.config['DB_CLIENT'])
     dbClient.createSession()
 
@@ -340,6 +344,7 @@ def collectionDeleteWorkEdition(uuid, user=None):
 
         return APIUtils.formatResponseObject(400, 'deleteCollectionWorkEdition', errMsg)
 
+    # TODO: Connect to write client: https://newyorkpubliclibrary.atlassian.net/browse/SFR-2668
     dbClient = DBClient(current_app.config['DB_CLIENT'])
     dbClient.createSession()
 

--- a/etl-pipeline/config/production.yaml
+++ b/etl-pipeline/config/production.yaml
@@ -4,8 +4,9 @@ ENVIRONMENT: production
 LOG_LEVEL: info
 
 # POSTGRES CONNECTION DETAILS
-# POSTGRES_USER, POSTGRES_PSWD, POSTGRES_ADMIN_USER and POSTGRES_ADMIN_PSWD must be configured in secrets file 
+# POSTGRES_USER, POSTGRES_PSWD, POSTGRES_ADMIN_USER and POSTGRES_ADMIN_PSWD must be configured in secrets file
 POSTGRES_HOST: sfr-new-metadata-production-cluster.cluster-cvy7z512hcjg.us-east-1.rds.amazonaws.com
+POSTGRES_READ_HOST: sfr-new-metadata-production-cluster.cluster-ro-cvy7z512hcjg.us-east-1.rds.amazonaws.com
 POSTGRES_NAME: dcdw_production
 POSTGRES_PORT: '5432'
 

--- a/etl-pipeline/config/qa.yaml
+++ b/etl-pipeline/config/qa.yaml
@@ -6,6 +6,7 @@ LOG_LEVEL: info
 # POSTGRES CONNECTION DETAILS
 # POSTGRES_USER, POSTGRES_PSWD, POSTGRES_ADMIN_USER and POSTGRES_ADMIN_PSWD must be configured in secrets file
 POSTGRES_HOST: sfr-new-metadata-qa-cluster.cluster-cvy7z512hcjg.us-east-1.rds.amazonaws.com
+POSTGRES_READ_HOST: sfr-new-metadata-qa-cluster.cluster-ro-cvy7z512hcjg.us-east-1.rds.amazonaws.com
 POSTGRES_NAME: dcdw_qa
 POSTGRES_PORT: '5432'
 

--- a/etl-pipeline/processes/api.py
+++ b/etl-pipeline/processes/api.py
@@ -1,3 +1,5 @@
+import os
+
 from api.app import FlaskAPI
 from logger import create_log
 from managers import DBManager, ElasticsearchManager, RedisManager
@@ -7,7 +9,8 @@ logger = create_log(__name__)
 
 class APIProcess:
     def __init__(self, *args):
-        self.db_manager = DBManager()
+        host = os.environ.get("POSTGRES_READ_HOST")
+        self.db_manager = DBManager(host=host)
         self.elastic_search_manager = ElasticsearchManager()
         self.redis_manager = RedisManager()
 


### PR DESCRIPTION
## Describe your changes
The API *generally* doesn't write data to the DB, so point it at the read replica so that things run smoothly if data ingests are doing a lot of writes.
https://newyorkpubliclibrary.atlassian.net/browse/SFR-2666

## How to test
`python -m main -p APIProcess -e local-{qa|production}` and hit localhost:5050