### PR TITLE
Fix: local seed script

### DIFF
--- a/etl-pipeline/docker-compose.setup.yml
+++ b/etl-pipeline/docker-compose.setup.yml
@@ -18,6 +18,11 @@ services:
     extends:
       file: docker-compose.yml
       service: rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_port_connectivity"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
 
   redis:
     extends:
@@ -32,12 +37,19 @@ services:
   seeddb:
     container_name: drb_local_seed
     depends_on:
-      - devsetup
-      - database
-      - elasticsearch
-      - s3
-      - redis
-      - rabbitmq
+      devsetup:
+        condition: service_started
+      database:
+        condition: service_started
+      elasticsearch:
+        condition: service_started
+      s3:
+        condition: service_started
+      redis:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
+
     build:
       context: .
     command: -e local-compose -p SeedLocalDataProcess -i daily

--- a/etl-pipeline/services/sources/hathi_trust_service.py
+++ b/etl-pipeline/services/sources/hathi_trust_service.py
@@ -19,7 +19,7 @@ logger = create_log(__name__)
 class HathiTrustService(SourceService):
     HATHI_DATAFILES = 'https://www.hathitrust.org/files/hathifiles/hathi_file_list.json'
     HATHI_RIGHTS_SKIPS = ['ic', 'icus', 'ic-world', 'und']
-    FIELD_SIZE_LIMIT = 131072 * 2 # 131072 is the default size limit
+    FIELD_SIZE_LIMIT = 131072 * 16 # 131072 is the default size limit
 
     def __init__(self):
         self.constants = get_constants()


### PR DESCRIPTION
## Describe your changes

- Introduces a healthcheck to the RabbitMQ container in the `docker-compose.setup.yml` and then uses that to make sure that RabbitMQ is ready before running the `drb_local_seed` container by depending on the health check. 
- Increases the HathiTrust TSV field size limit by 8x since I was getting errors about hitting the limit while seeding my DB. A slightly lower limit may work, but I also tried 4x and that didn't work. 

## How to test

- Run the setup process using `docker compose -f docker-compose.setup.yml up --abort-on-container-exit` and ensure the seed completes without errors. You might try wiping local data before doing that so you can be sure it actually added data