### PR TITLE
NO-REF: Reduce API task memory

### DIFF
--- a/etl-pipeline/api/app.py
+++ b/etl-pipeline/api/app.py
@@ -43,22 +43,11 @@ class FlaskAPI:
         self.app.register_blueprint(fulfill)
 
     def run(self):
-        if 'local-compose' in os.environ['ENVIRONMENT'] or 'sample-compose' in os.environ['ENVIRONMENT']:
-            logger.debug('Starting dev server on port 5050')
-
+        if os.environ.get('STAGE') == 'development':
             self.app.config['ENV'] = 'development'
             self.app.config['DEBUG'] = True
-            self.app.run(host='0.0.0.0', port=5050)
-
-        elif 'local' in os.environ['ENVIRONMENT']:
-            logger.debug('Starting dev server on port 5050')
-
-            self.app.config['ENV'] = 'development'
-            self.app.config['DEBUG'] = True
-            self.app.run(port=5050)
+            self.app.run(host=os.environ.get('API_HOST'), port=5050)
         else:
-            logger.debug('Starting production server on port 80')
-
             serve(self.app, host='0.0.0.0', port=80)
 
     def createErrorResponses(self):

--- a/etl-pipeline/api/db.py
+++ b/etl-pipeline/api/db.py
@@ -214,13 +214,6 @@ class DBClient():
 
         return (
             self.session.query(Collection)
-                .options(
-                    joinedload(Collection.editions),
-                    joinedload(Collection.editions, Edition.links),
-                    joinedload(Collection.editions, Edition.items),
-                    joinedload(Collection.editions, Edition.items, Item.links),
-                    joinedload(Collection.editions, Edition.items, Item.rights),
-                )
                 .order_by(text(sort))
                 .offset(offset)
                 .limit(perPage)

--- a/etl-pipeline/config/local-compose.yaml
+++ b/etl-pipeline/config/local-compose.yaml
@@ -1,4 +1,7 @@
-STAGE: local
+ENVIRONMENT: local
+STAGE: development
+
+API_HOST: '0.0.0.0'
 
 LOG_LEVEL: info
 

--- a/etl-pipeline/config/local.yaml
+++ b/etl-pipeline/config/local.yaml
@@ -1,4 +1,5 @@
 ENVIRONMENT: local
+STAGE: development
 
 LOG_LEVEL: INFO
 

--- a/etl-pipeline/tests/unit/test_api_app.py
+++ b/etl-pipeline/tests/unit/test_api_app.py
@@ -15,6 +15,7 @@ class TestFlaskAPI:
 
     def test_run_local(self, testInstance):
         os.environ['ENVIRONMENT'] = 'local'
+        os.environ['STAGE'] = 'development'
 
         testInstance.run()
 
@@ -22,6 +23,7 @@ class TestFlaskAPI:
 
     def test_run_production(self, testInstance, mocker):
         os.environ['ENVIRONMENT'] = 'production'
+        del os.environ['STAGE']
         mockServe = mocker.patch('api.app.serve')
 
         testInstance.run()


### PR DESCRIPTION
## Describe your changes
- Fixes the env issues with running on local-qa or local-production
- You'll need to add STAGE: development to those files if you want to run the API locally but against qa or production

## How to test
`python main.py -p APIProcess -e local-qa`