### PR TITLE
Write record ingest messages to SQS

### DIFF
--- a/etl-pipeline/managers/sqs.py
+++ b/etl-pipeline/managers/sqs.py
@@ -10,13 +10,18 @@ logger = create_log(__name__)
 
 
 class SQSManager:
-    def __init__(self, visibility_timeout=30, max_receive_count=1, wait_time_seconds=10):
-        super(SQSManager, self).__init__()
+    def __init__(
+        self,
+        queue_name: str,
+        visibility_timeout=30,
+        max_receive_count=1,
+        wait_time_seconds=10,
+    ):
         self.region_name = os.environ.get("AWS_REGION", "us-east-1")
         self.endpoint_url = os.environ.get("S3_ENDPOINT_URL")
         self.aws_access_key_id = os.environ.get("AWS_ACCESS")
         self.aws_secret_access_key = os.environ.get("AWS_SECRET")
-        self.queue_name = os.environ.get("RECORD_PIPELINE_SQS_QUEUE", "records")
+        self.queue_name = queue_name
         self.visibility_timeout = visibility_timeout
         self.max_receive_count = max_receive_count
         self.wait_time_seconds = wait_time_seconds
@@ -47,7 +52,7 @@ class SQSManager:
         params = {
             "QueueUrl": self.queue_url,
             "MessageBody": message,
-            }
+        }
 
         try:
             response = self.client.send_message(**params)

--- a/etl-pipeline/processes/record_ingestor.py
+++ b/etl-pipeline/processes/record_ingestor.py
@@ -3,7 +3,7 @@ import os
 import typing
 
 from logger import create_log
-from managers import RabbitMQManager
+from managers import RabbitMQManager, SQSManager
 from model import Record
 
 logger = create_log(__name__)
@@ -17,26 +17,35 @@ class RecordIngestor:
         self.records_queue = os.environ['RECORD_PIPELINE_QUEUE']
         self.records_route = os.environ['RECORD_PIPELINE_ROUTING_KEY']
 
-        self.queue_mananger = RabbitMQManager()
-        self.queue_mananger.create_connection()
-        self.queue_mananger.create_or_connect_queue(self.records_queue, self.records_route)
+        self.queue_manager = RabbitMQManager()
+        self.queue_manager.create_connection()
+        self.queue_manager.create_or_connect_queue(self.records_queue, self.records_route)
+
+        sqs_records_queue = os.environ["RECORD_PIPELINE_SQS_QUEUE"]
+        self.sqs_manager = SQSManager(queue_name=sqs_records_queue)
+
 
     def ingest(self, records: typing.Iterator[Record]) -> int:
         ingest_count = 0
 
         try:
             for record in records:
-                self.queue_mananger.send_message_to_queue(
+                message = json.dumps(record.to_dict(), default=str)
+                self.queue_manager.send_message_to_queue(
                     queue_name=self.records_queue,
                     routing_key=self.records_route,
-                    message=json.dumps(record.to_dict(), default=str)
+                    message=message,
                 )
-                
                 ingest_count += 1
+                try:
+                    self.sqs_manager.send_message_to_queue(message)
+                except Exception as e:
+                    logger.exception(f"Failed to send message to SQS")
+
         except Exception:
             logger.exception(f'Failed to ingest {self.source} records')
         finally:
-            self.queue_mananger.close_connection()
+            self.queue_manager.close_connection()
 
         logger.info(f'Ingested {ingest_count} {self.source} records')
         return ingest_count

--- a/etl-pipeline/tests/integration/test_sqs.py
+++ b/etl-pipeline/tests/integration/test_sqs.py
@@ -8,11 +8,10 @@ from managers import SQSManager
 def sqs_manager(monkeypatch):
     """Fixture providing an SQSManager instance configured for LocalStack"""
     monkeypatch.setenv('AWS_REGION','us-east-1')
-    monkeypatch.setenv('RECORD_PIPELINE_SQS_QUEUE', 'test-queue')
     monkeypatch.setenv('AWS_ACCESS', 'test-access-key')
     monkeypatch.setenv('AWS_SECRET', 'test-secret-key')
     monkeypatch.setenv('S3_ENDPOINT_URL', 'http://localhost:4566')
-    manager = SQSManager()
+    manager = SQSManager("test-queue")
     return manager
 
 class TestSQSManagerIntegration:

--- a/etl-pipeline/tests/unit/test_sqs.py
+++ b/etl-pipeline/tests/unit/test_sqs.py
@@ -11,7 +11,6 @@ class TestSQSManager(unittest.TestCase):
         "AWS_ACCESS_KEY_ID": "test-key",
         "AWS_SECRET_ACCESS_KEY": "test-secret",
         "AWS_REGION": "us-east-1",
-        "RECORD_PIPELINE_SQS_QUEUE": "test-queue"
     })
     @patch('managers.sqs.boto3.client')
     def setUp(self, mock_client):
@@ -21,7 +20,7 @@ class TestSQSManager(unittest.TestCase):
         mock_client.return_value = self.mock_sqs
 
         # Create manager and fully mock its client initialization
-        self.manager = SQSManager()
+        self.manager = SQSManager("test-queue")
         self.manager.client = self.mock_sqs
         self.manager.queue_url = 'test-url'
         self.manager.create_client = MagicMock(return_value=None)  # Prevent real client creation


### PR DESCRIPTION
## Describe your changes
To do a final check that the queue is configured properly in AWS, start
writing messages to SQS, so we can validate they can be written and the
message format is as expected. Once this is validated, we can purge the
queue, update the record pipeline to read from the queue, and remove the
RabbitMQ step

## How to test

Run `make functional`, then observe the messages in the queue in the localstack UI
