### PR TITLE
Add `state` column to record table

### DIFF
--- a/etl-pipeline/migrations/versions/eb6ce7780436_add_record_state.py
+++ b/etl-pipeline/migrations/versions/eb6ce7780436_add_record_state.py
@@ -1,0 +1,37 @@
+"""Add record state
+
+Revision ID: eb6ce7780436
+Revises: 0cebb9a98a6f
+Create Date: 2025-04-24 11:09:19.838900
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM
+
+
+# revision identifiers, used by Alembic.
+revision = 'eb6ce7780436'
+down_revision = '0cebb9a98a6f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "records",
+        # See model.postgres.record for values. Enums with `create_type=False`
+        # are basically just plain strings anyway without any constraints and
+        # I couldn't get alembic to play nice with it:
+        # https://github.com/sqlalchemy/alembic/issues/1347
+        sa.Column(
+            "state",
+            sa.String,
+            nullable=True,
+            index=True,
+        ),
+    )
+
+
+def downgrade():
+    pass

--- a/etl-pipeline/migrations/versions/fabf5e5c3109_add_collections_table.py
+++ b/etl-pipeline/migrations/versions/fabf5e5c3109_add_collections_table.py
@@ -1,7 +1,7 @@
 """add collections table
 
 Revision ID: fabf5e5c3109
-Revises: 
+Revises:
 Create Date: 2021-08-04 18:05:01.567042
 
 """
@@ -29,7 +29,8 @@ def upgrade():
         ),
         sa.Column('uuid', UUID, index=True),
         sa.Column('title', sa.String, index=True),
-        sa.Column('creator', sa.String, index=True)
+        sa.Column('creator', sa.String, index=True),
+        if_not_exists=True,
     )
 
     op.create_table(
@@ -50,7 +51,8 @@ def upgrade():
             sa.Integer,
             sa.ForeignKey('editions.id', ondelete='CASCADE'),
             index=True
-        )
+        ),
+        if_not_exists=True,
     )
 
 

--- a/etl-pipeline/model/postgres/record.py
+++ b/etl-pipeline/model/postgres/record.py
@@ -29,22 +29,22 @@ class Part:
 
         if 'localhost' in parsed_url.hostname:
             path_parts = parsed_url.path.split('/')
-            
+
             return path_parts[1]
 
         if 's3' not in parsed_url.hostname:
             return None
-        
+
         return parsed_url.hostname.split('.')[0]
-    
+
     @property
     def file_bucket(self) -> Optional[str]:
         return self._parse_file_bucket(self.url)
-    
+
     @property
     def source_file_bucket(self) -> Optional[str]:
         return self._parse_file_bucket(self.source_url)
-    
+
     def _parse_file_key(self, url: Optional[str]) -> Optional[str]:
         if url is None:
             return None
@@ -58,23 +58,23 @@ class Part:
 
         if 's3' not in parsed_url.hostname:
             return None
-        
+
         return parsed_url.path[1:]
 
     @property
     def file_key(self) -> Optional[str]:
         return self._parse_file_key(self.url)
-    
+
     @property
     def source_file_key(self) -> Optional[str]:
         return self._parse_file_key(self.source_url)
-    
+
     def __str__(self):
         fields = [
-            str(self.index) if self.index is not None else '', 
-            self.url, 
-            self.source, 
-            self.file_type, 
+            str(self.index) if self.index is not None else '',
+            self.url,
+            self.source,
+            self.file_type,
             self.flags
         ]
 
@@ -89,7 +89,7 @@ class FRBRStatus(Enum):
     COMPLETE = 'complete'
 
 
-@dataclass 
+@dataclass
 class FileFlags:
     catalog: bool = False
     reader: bool = False
@@ -114,6 +114,15 @@ class Record(Base, Core):
         index=True
     )
     cluster_status = Column(Boolean, default=False, nullable=False, index=True)
+    state = Column(
+        Unicode,
+        ENUM(
+            "ingested", "files_saved", "complete",
+            name="record_state", create_type=False,
+        ),
+        nullable=True,
+        index=True,
+    )
     source = Column(Unicode, index=True) # dc:source, Non-Repeating
     publisher_project_source = Column(Unicode, index=True) # dc:publisherProjectSource, Non-Repeating
     source_id = Column(Unicode, index=True) # dc:identifier, Non-Repeating
@@ -153,7 +162,7 @@ class Record(Base, Core):
         title = shorten(self.title, width=50, placeholder='...') if self.title else self.title
 
         return f"<Record(title={title}, source={self.source} uuid={self.uuid})>"
-    
+
     def __dir__(self):
         return ['uuid', 'frbr_status', 'cluster_status', 'source', 'publisher_project_source', 'source_id',
             'title', 'alternative', 'medium', 'is_part_of', 'subjects', 'authors',
@@ -161,7 +170,7 @@ class Record(Base, Core):
             'date_submitted', 'requires', 'spatial', 'publisher', 'has_version',
             'table_of_contents', 'extent', 'abstract', 'has_part', 'coverage', 'date_modified'
         ]
-    
+
     def __iter__(self):
         for attr in dir(self):
             yield attr, getattr(self, attr)
@@ -209,7 +218,7 @@ class Record(Base, Core):
     @property
     def deletion_flag(self):
         return self._deletion_flag
-    
+
     @deletion_flag.setter
     def deletion_flag(self, deletion_flag):
         self._deletion_flag = deletion_flag


### PR DESCRIPTION
This column will eventually supplant cluster_status and frbr_status, and the new `ingested` state will allow us to persist records during ingested to reduce SQS payload size

## Describe your changes

## How to test
ran `alembic upgrade head` locally, checked DB 