### PR TITLE
Add `state` column to record table

### DIFF
--- a/etl-pipeline/migrations/versions/eb6ce7780436_add_record_state.py
+++ b/etl-pipeline/migrations/versions/eb6ce7780436_add_record_state.py
@@ -1,0 +1,37 @@
+"""Add record state
+
+Revision ID: eb6ce7780436
+Revises: 0cebb9a98a6f
+Create Date: 2025-04-24 11:09:19.838900
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM
+
+
+# revision identifiers, used by Alembic.
+revision = 'eb6ce7780436'
+down_revision = '0cebb9a98a6f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "records",
+        # See model.postgres.record for values. Enums with `create_type=False`
+        # are basically just plain strings anyway without any constraints and
+        # I couldn't get alembic to play nice with it:
+        # https://github.com/sqlalchemy/alembic/issues/1347
+        sa.Column(
+            "state",
+            sa.String,
+            nullable=True,
+            index=True,
+        ),
+    )
+
+
+def downgrade():
+    pass

--- a/etl-pipeline/migrations/versions/eb6ce7780436_add_record_state.py
+++ b/etl-pipeline/migrations/versions/eb6ce7780436_add_record_state.py
@@ -18,20 +18,8 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column(
-        "records",
-        # See model.postgres.record for values. Enums with `create_type=False`
-        # are basically just plain strings anyway without any constraints and
-        # I couldn't get alembic to play nice with it:
-        # https://github.com/sqlalchemy/alembic/issues/1347
-        sa.Column(
-            "state",
-            sa.String,
-            nullable=True,
-            index=True,
-        ),
-    )
+    op.add_column('records', sa.Column('state', sa.String, nullable=True))
 
 
 def downgrade():
-    pass
+    op.drop_column('records', 'state')

--- a/etl-pipeline/model/postgres/record.py
+++ b/etl-pipeline/model/postgres/record.py
@@ -116,12 +116,8 @@ class Record(Base, Core):
     cluster_status = Column(Boolean, default=False, nullable=False, index=True)
     state = Column(
         Unicode,
-        ENUM(
-            "ingested", "files_saved", "complete",
-            name="record_state", create_type=False,
-        ),
-        nullable=True,
-        index=True,
+        ENUM('ingested', 'files_saved', 'embellished', 'clustered', name='record_state', create_type=False),
+        nullable=True
     )
     source = Column(Unicode, index=True) # dc:source, Non-Repeating
     publisher_project_source = Column(Unicode, index=True) # dc:publisherProjectSource, Non-Repeating

--- a/etl-pipeline/model/postgres/record.py
+++ b/etl-pipeline/model/postgres/record.py
@@ -114,6 +114,15 @@ class Record(Base, Core):
         index=True
     )
     cluster_status = Column(Boolean, default=False, nullable=False, index=True)
+    state = Column(
+        Unicode,
+        ENUM(
+            "ingested", "files_saved", "complete",
+            name="record_state", create_type=False,
+        ),
+        nullable=True,
+        index=True,
+    )
     source = Column(Unicode, index=True) # dc:source, Non-Repeating
     publisher_project_source = Column(Unicode, index=True) # dc:publisherProjectSource, Non-Repeating
     source_id = Column(Unicode, index=True) # dc:identifier, Non-Repeating


### PR DESCRIPTION
This column will eventually supplant cluster_status and frbr_status, and the new ingested state will allow us to persist records during ingested to reduce SQS payload size

## Describe your changes

## How to test
`alembic upgrade head`, look at DB