### PR TITLE
SFR-2678: Persist records and set state in ingestor

### DIFF
--- a/etl-pipeline/mappings/oclcCatalog.py
+++ b/etl-pipeline/mappings/oclcCatalog.py
@@ -4,6 +4,7 @@ import requests
 from requests.exceptions import ReadTimeout, HTTPError
 
 from mappings.xml import XMLMapping
+from model import RecordState
 from logger import create_log
 
 logger = create_log(__name__)
@@ -173,7 +174,9 @@ class CatalogMapping(XMLMapping):
         self.record.source_id = f'{oclc_number}|oclc'
         self.record.identifiers[0] = self.record.source_id
 
+        # TODO: deprecate frbr_status
         self.record.frbr_status = 'complete'
+        self.record.state = RecordState.EMBELLISHED.value
 
         _, _, lang_3, *_ = tuple(self.record.languages[0].split('|'))
         self.record.languages = [('||{}'.format(lang_3[35:38]))]

--- a/etl-pipeline/mappings/oclc_bib.py
+++ b/etl-pipeline/mappings/oclc_bib.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Optional
 from uuid import uuid4
 
-from model import Record
+from model import Record, RecordState
 from .base_mapping import BaseMapping
 
 
@@ -21,6 +21,7 @@ class OCLCBibMapping(BaseMapping):
             uuid=uuid4(),
             frbr_status='complete',
             cluster_status=False,
+            state=RecordState.EMBELLISHED.value,
             source='oclcClassify',
             source_id=f"{oclc_bib.get('work', {}).get('id')}|owi",
             title=oclc_bib.get('title', {}).get('mainTitles', [{}])[0].get('text'),

--- a/etl-pipeline/migrations/versions/eb6ce7780436_add_record_state.py
+++ b/etl-pipeline/migrations/versions/eb6ce7780436_add_record_state.py
@@ -1,0 +1,37 @@
+"""Add record state
+
+Revision ID: eb6ce7780436
+Revises: 0cebb9a98a6f
+Create Date: 2025-04-24 11:09:19.838900
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ENUM
+
+
+# revision identifiers, used by Alembic.
+revision = 'eb6ce7780436'
+down_revision = '0cebb9a98a6f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "records",
+        # See model.postgres.record for values. Enums with `create_type=False`
+        # are basically just plain strings anyway without any constraints and
+        # I couldn't get alembic to play nice with it:
+        # https://github.com/sqlalchemy/alembic/issues/1347
+        sa.Column(
+            "state",
+            sa.String,
+            nullable=True,
+            index=True,
+        ),
+    )
+
+
+def downgrade():
+    pass

--- a/etl-pipeline/model/__init__.py
+++ b/etl-pipeline/model/__init__.py
@@ -1,5 +1,5 @@
 from .postgres.base import Base, Core
-from .postgres.record import Record, Part, FRBRStatus, FileFlags
+from .postgres.record import Record, Part, FRBRStatus, FileFlags, RecordState
 from .postgres.work import Work
 from .postgres.edition import Edition
 from .postgres.item import Item

--- a/etl-pipeline/model/postgres/record.py
+++ b/etl-pipeline/model/postgres/record.py
@@ -92,7 +92,7 @@ class FRBRStatus(Enum):
 class RecordState(Enum):
     INGESTED = 'ingested'
     FILES_SAVED = 'files_saved'
-    EMBELLISED = 'embellished'
+    EMBELLISHED = 'embellished'
     CLUSTERED = 'clustered'
 
 

--- a/etl-pipeline/model/postgres/record.py
+++ b/etl-pipeline/model/postgres/record.py
@@ -114,6 +114,15 @@ class Record(Base, Core):
         index=True
     )
     cluster_status = Column(Boolean, default=False, nullable=False, index=True)
+    state = Column(
+        Unicode,
+        ENUM(
+            "ingested", "files_saved", "complete",
+            name="record_state", create_type=False,
+        ),
+        nullable=True,
+        index=True,
+    )
     source = Column(Unicode, index=True) # dc:source, Non-Repeating
     publisher_project_source = Column(Unicode, index=True) # dc:publisherProjectSource, Non-Repeating
     source_id = Column(Unicode, index=True) # dc:identifier, Non-Repeating

--- a/etl-pipeline/model/postgres/record.py
+++ b/etl-pipeline/model/postgres/record.py
@@ -89,6 +89,13 @@ class FRBRStatus(Enum):
     COMPLETE = 'complete'
 
 
+class RecordState(Enum):
+    INGESTED = 'ingested'
+    FILES_SAVED = 'files_saved'
+    EMBELLISED = 'embellished'
+    CLUSTERED = 'clustered'
+
+
 @dataclass 
 class FileFlags:
     catalog: bool = False

--- a/etl-pipeline/model/postgres/record.py
+++ b/etl-pipeline/model/postgres/record.py
@@ -157,17 +157,13 @@ class Record(Base, Core):
         super().__init__(*args, **kwargs)
         self._deletion_flag = False
 
-    # Because SQL alchemy uses __dict__ and vars, we must use a separate to_dict function to make a Record JSON serializable
-    def to_dict(self):
-        return { attribute: value for attribute, value in self }
-
     def __repr__(self):
         title = shorten(self.title, width=50, placeholder='...') if self.title else self.title
 
         return f"<Record(title={title}, source={self.source} uuid={self.uuid})>"
     
     def __dir__(self):
-        return ['uuid', 'frbr_status', 'cluster_status', 'source', 'publisher_project_source', 'source_id',
+        return ['uuid', 'frbr_status', 'cluster_status', 'state', 'source', 'publisher_project_source', 'source_id',
             'title', 'alternative', 'medium', 'is_part_of', 'subjects', 'authors',
             'contributors', 'languages', 'dates', 'rights', 'identifiers',
             'date_submitted', 'requires', 'spatial', 'publisher', 'has_version',

--- a/etl-pipeline/processes/record_buffer.py
+++ b/etl-pipeline/processes/record_buffer.py
@@ -33,7 +33,7 @@ class RecordBuffer:
         self.db_manager.bulk_save_objects(self.records)
         self.ingest_count += len(self.records)
 
-        yield iter(self.records)
+        yield from iter(self.records)
 
         self.records.clear()
 

--- a/etl-pipeline/processes/record_buffer.py
+++ b/etl-pipeline/processes/record_buffer.py
@@ -1,3 +1,5 @@
+from typing import Optional, Iterable
+
 from managers import DBManager
 from model import Record, FRBRStatus
 
@@ -10,7 +12,7 @@ class RecordBuffer:
         self.ingest_count = 0
         self.deletion_count = 0
 
-    def add(self, record: Record):
+    def add(self, record: Record) -> Optional[Iterable[Record]]:
         existing_record = self.db_manager.session.query(Record).filter(
             Record.source_id == record.source_id
         ).first()
@@ -27,21 +29,12 @@ class RecordBuffer:
 
         return None
 
-
-    # TODO: Implement deletion for the rest of the FRBR model
-    def delete(self, record: Record):
-        existing_record = self.db_manager.session.query(Record).filter(
-            Record.source_id == record.source_id
-        ).first()
-
-        if existing_record:
-            self.db_manager.session.delete(existing_record)
-            self.deletion_count += 1
-            self.db_manager.session.commit()
-
-    def flush(self):
+    def flush(self) -> Iterable[Record]:
         self.db_manager.bulk_save_objects(self.records)
         self.ingest_count += len(self.records)
+
+        yield iter(self.records)
+
         self.records.clear()
 
     def _update_record(self, record: Record, existing_record: Record) -> Record:

--- a/etl-pipeline/processes/record_buffer.py
+++ b/etl-pipeline/processes/record_buffer.py
@@ -23,7 +23,10 @@ class RecordBuffer:
             self.records.add(record)
 
         if len(self.records) > self.batch_size:
-            self.flush()
+            return self.flush()
+
+        return None
+
 
     # TODO: Implement deletion for the rest of the FRBR model
     def delete(self, record: Record):

--- a/etl-pipeline/processes/record_clusterer.py
+++ b/etl-pipeline/processes/record_clusterer.py
@@ -9,7 +9,7 @@ from managers import (
     SFRRecordManager,
 )
 from constants.get_constants import get_constants
-from model import Record, Work
+from model import Record, Work, RecordState
 
 
 logger = create_log(__name__)
@@ -129,7 +129,7 @@ class RecordClusterer:
         (
             self.db_manager.session.query(Record)
             .filter(Record.id.in_(list(set(record_ids))))
-            .update({"cluster_status": cluster_status, "frbr_status": "complete"})
+            .update({"cluster_status": cluster_status, "frbr_status": "complete", "state": RecordState.CLUSTERED.value })
         )
 
     def _find_all_matching_records(self, record: Record) -> list[str]:

--- a/etl-pipeline/processes/record_embellisher.py
+++ b/etl-pipeline/processes/record_embellisher.py
@@ -35,7 +35,7 @@ class RecordEmbellisher:
     def embellish_record(self, record: Record) -> Record:
         self._add_works_for_record(record=record)
 
-        self.record_buffer.flush(yield_records=False)
+        self.record_buffer.flush()
 
         # TODO: deprecate frbr_status
         record.frbr_status = 'complete'
@@ -67,7 +67,6 @@ class RecordEmbellisher:
             self._add_works(self.oclc_catalog_manager.query_bibs(query=search_query))
 
     def _add_works(self, oclc_bibs: list):
-        print(oclc_bibs)
         """Process a list of OCLC bibliographic records."""
         for oclc_bib in oclc_bibs:
             owi_number, related_oclc_numbers = self._add_work(oclc_bib) 
@@ -93,7 +92,7 @@ class RecordEmbellisher:
         related_oclc_numbers = self.oclc_catalog_manager.get_related_oclc_numbers(oclc_number=oclc_number)
 
         oclc_bib_mapping = OCLCBibMapping(oclc_bib=oclc_bib,related_oclc_numbers=list(set(related_oclc_numbers)))
-        self.record_buffer.add(record=oclc_bib_mapping.record, yield_records=False)
+        self.record_buffer.add(record=oclc_bib_mapping.record)
 
         return (owi_number, related_oclc_numbers)
 
@@ -107,7 +106,7 @@ class RecordEmbellisher:
             catalog_record_mapping.applyMapping()
             catalog_record_mapping.record.identifiers.append(f'{owi_number}|owi')
             
-            self.record_buffer.add(catalog_record_mapping.record, yield_records=False)
+            self.record_buffer.add(catalog_record_mapping.record)
         except Exception:
             logger.exception(f'Unable to add edition with OCLC number: {oclc_number}')
             return

--- a/etl-pipeline/processes/record_embellisher.py
+++ b/etl-pipeline/processes/record_embellisher.py
@@ -35,7 +35,7 @@ class RecordEmbellisher:
     def embellish_record(self, record: Record) -> Record:
         self._add_works_for_record(record=record)
 
-        self.record_buffer.flush()
+        self.record_buffer.flush(yield_records=False)
 
         # TODO: deprecate frbr_status
         record.frbr_status = 'complete'
@@ -67,6 +67,7 @@ class RecordEmbellisher:
             self._add_works(self.oclc_catalog_manager.query_bibs(query=search_query))
 
     def _add_works(self, oclc_bibs: list):
+        print(oclc_bibs)
         """Process a list of OCLC bibliographic records."""
         for oclc_bib in oclc_bibs:
             owi_number, related_oclc_numbers = self._add_work(oclc_bib) 
@@ -92,7 +93,7 @@ class RecordEmbellisher:
         related_oclc_numbers = self.oclc_catalog_manager.get_related_oclc_numbers(oclc_number=oclc_number)
 
         oclc_bib_mapping = OCLCBibMapping(oclc_bib=oclc_bib,related_oclc_numbers=list(set(related_oclc_numbers)))
-        self.record_buffer.add(record=oclc_bib_mapping.record)
+        self.record_buffer.add(record=oclc_bib_mapping.record, yield_records=False)
 
         return (owi_number, related_oclc_numbers)
 
@@ -106,7 +107,7 @@ class RecordEmbellisher:
             catalog_record_mapping.applyMapping()
             catalog_record_mapping.record.identifiers.append(f'{owi_number}|owi')
             
-            self.record_buffer.add(catalog_record_mapping.record)
+            self.record_buffer.add(catalog_record_mapping.record, yield_records=False)
         except Exception:
             logger.exception(f'Unable to add edition with OCLC number: {oclc_number}')
             return

--- a/etl-pipeline/processes/record_embellisher.py
+++ b/etl-pipeline/processes/record_embellisher.py
@@ -5,7 +5,7 @@ from logger import create_log
 from mappings.oclc_bib import OCLCBibMapping
 from mappings.oclcCatalog import CatalogMapping
 from managers import DBManager, OCLCCatalogManager, RedisManager
-from model import Record
+from model import Record, RecordState
 from .record_buffer import RecordBuffer
 
 
@@ -37,11 +37,12 @@ class RecordEmbellisher:
 
         self.record_buffer.flush()
 
-        # TODO: change this to embellish_status
+        # TODO: deprecate frbr_status
         record.frbr_status = 'complete'
+        record.state = RecordState.EMBELLISHED.value
 
-        self.db_manager.session.add(record)
         self.db_manager.session.commit()
+        self.db_manager.session.refresh(record)
 
         logger.info(f'Embellished record: {record}')
 

--- a/etl-pipeline/processes/record_ingestor.py
+++ b/etl-pipeline/processes/record_ingestor.py
@@ -3,8 +3,9 @@ import os
 import typing
 
 from logger import create_log
-from managers import RabbitMQManager, SQSManager
+from managers import DBManager, RabbitMQManager, SQSManager
 from model import Record
+from processes.record_buffer import RecordBuffer
 
 logger = create_log(__name__)
 
@@ -13,6 +14,11 @@ class RecordIngestor:
 
     def __init__(self, source: str):
         self.source = source
+
+        db_manager = DBManager()
+        db_manager.create_session()
+
+        self.record_buffer = RecordBuffer(db_manager=db_manager)
 
         self.records_queue = os.environ['RECORD_PIPELINE_QUEUE']
         self.records_route = os.environ['RECORD_PIPELINE_ROUTING_KEY']
@@ -29,15 +35,15 @@ class RecordIngestor:
         ingest_count = 0
 
         try:
-            for record in records:
-                message = json.dumps(record.to_dict(), default=str)
+            for record in self._persisted_records(records):
                 self.queue_manager.send_message_to_queue(
                     queue_name=self.records_queue,
                     routing_key=self.records_route,
-                    message=message,
+                    message=json.dumps(record.to_dict(), default=str),
                 )
                 ingest_count += 1
                 try:
+                    message = json.dumps({"record_id": record.id})
                     self.sqs_manager.send_message_to_queue(message)
                 except Exception as e:
                     logger.exception(f"Failed to send message to SQS")
@@ -49,3 +55,15 @@ class RecordIngestor:
 
         logger.info(f'Ingested {ingest_count} {self.source} records')
         return ingest_count
+
+    def _persisted_records(
+        self,
+        records: typing.Iterator[Record],
+    ) -> typing.Iterator[Record]:
+        for record in records:
+            record.state = "ingested"
+            flushed_records = self.record_buffer.add(record)
+            if flushed_records:
+                yield from iter(flushed_records)
+
+        yield from iter(self.record_buffer.flush())

--- a/etl-pipeline/processes/record_ingestor.py
+++ b/etl-pipeline/processes/record_ingestor.py
@@ -33,7 +33,7 @@ class RecordIngestor:
     def ingest(self, records: Iterator[Record]) -> int:
         try:
             for record in self._persisted_records(records):
-                message = { "record_id": record.id }
+                message = { "source_id": record.source_id, "source": record.source }
 
                 self.queue_manager.send_message_to_queue(
                     queue_name=self.records_queue,

--- a/etl-pipeline/processes/record_ingestor.py
+++ b/etl-pipeline/processes/record_ingestor.py
@@ -33,18 +33,18 @@ class RecordIngestor:
     def ingest(self, records: Iterator[Record]) -> int:
         try:
             for record in self._persisted_records(records):
+                message = { "record_id": record.id }
+
                 self.queue_manager.send_message_to_queue(
                     queue_name=self.records_queue,
                     routing_key=self.records_route,
-                    message=json.dumps(record.to_dict(), default=str),
+                    message=message
                 )
 
                 try:
-                    message = json.dumps({"record_id": record.id})
                     self.sqs_manager.send_message_to_queue(message)
-                except Exception as e:
+                except Exception:
                     logger.exception(f"Failed to send message to SQS")
-
         except Exception:
             logger.exception(f'Failed to ingest {self.source} records')
         finally:

--- a/etl-pipeline/processes/record_pipeline.py
+++ b/etl-pipeline/processes/record_pipeline.py
@@ -39,6 +39,7 @@ class RecordPipelineProcess:
         self.record_deleter = RecordDeleter(db_manager=self.db_manager, store_manager=self.storage_manager, es_manager=self.es_manager)
 
     def runProcess(self, max_attempts: int=10):
+        self.db_manager.create_session()
         try:
              for attempt in range(0, max_attempts):
                 wait_time = 5 * attempt

--- a/etl-pipeline/processes/record_pipeline.py
+++ b/etl-pipeline/processes/record_pipeline.py
@@ -32,14 +32,13 @@ class RecordPipelineProcess:
         self.es_manager = ElasticsearchManager()
         self.es_manager.create_elastic_connection()
 
-        self.record_file_saver = RecordFileSaver(storage_manager=self.storage_manager)
+        self.record_file_saver = RecordFileSaver(db_manager=self.db_manager, storage_manager=self.storage_manager)
         self.record_embellisher = RecordEmbellisher(db_manager=self.db_manager)
         self.record_clusterer = RecordClusterer(db_manager=self.db_manager)
         self.link_fulfiller = LinkFulfiller(db_manager=self.db_manager)
         self.record_deleter = RecordDeleter(db_manager=self.db_manager, store_manager=self.storage_manager, es_manager=self.es_manager)
 
     def runProcess(self, max_attempts: int=10):
-        self.db_manager.create_session()
         try:
              for attempt in range(0, max_attempts):
                 wait_time = 5 * attempt
@@ -65,56 +64,29 @@ class RecordPipelineProcess:
     def _process_message(self, message):
         try:
             message_props, _, message_body = message
-            record = self._parse_message(message_body=message_body)
+            record_id = self._parse_message(message_body=message_body)
 
             self.db_manager.create_session()
 
-            if record._deletion_flag is True:
-                self.record_deleter.delete_record(record)
-            else:
-                self.record_file_saver.save_record_files(record)
-                saved_record = self._save_record(record)
-                embellished_record = self.record_embellisher.embellish_record(saved_record)
-                clustered_records = self.record_clusterer.cluster_record(embellished_record)
-                self.link_fulfiller.fulfill_records_links(clustered_records)
+            record = self.db_manager.session.get(Record, record_id)
+
+            if record is None:
+                raise Exception(f'Record with id: {record_id} not found')
+
+            record_with_files = self.record_file_saver.save_record_files(record)
+            embellished_record = self.record_embellisher.embellish_record(record_with_files)
+            clustered_records = self.record_clusterer.cluster_record(embellished_record)
+            self.link_fulfiller.fulfill_records_links(clustered_records)
                 
             self.queue_manager.acknowledge_message_processed(message_props.delivery_tag)
         except Exception:
-            logger.exception(f'Failed to process record: {record}')
+            logger.exception(f'Failed to process message: {message_body}')
             self.queue_manager.reject_message(delivery_tag=message_props.delivery_tag)         
         finally:
             if self.db_manager.session: 
                 self.db_manager.session.close()
 
-    def _parse_message(self, message_body) -> Record:
+    def _parse_message(self, message_body) -> int:
         message = json.loads(message_body)
 
-        return Record(**message)
-    
-    def _save_record(self, record: Record) -> Record:
-        existing_record = (
-            self.db_manager.session.query(Record)
-                .filter(Record.source_id == record.source_id)
-                .filter(Record.source == record.source)
-                .first()
-        )
-
-        if existing_record:
-            record = self._update_record(record, existing_record)
-        else:
-            self.db_manager.session.add(record)
-
-        self.db_manager.session.commit()
-        self.db_manager.session.refresh(record)
-
-        logger.info(f'{"Updated" if existing_record else "Created"} record: {record}')
-        return record
-    
-    def _update_record(self, record: Record, existing_record: Record) -> Record:
-        for attribute, value in record:
-            if attribute == 'uuid': 
-                continue
-
-            setattr(existing_record, attribute, value)
-
-        return existing_record
+        return int(message['record_id'])

--- a/etl-pipeline/processes/util/redrive_records.py
+++ b/etl-pipeline/processes/util/redrive_records.py
@@ -43,7 +43,7 @@ class RedriveRecordsProcess:
                 self.rabbitmq_manager.send_message_to_queue(
                     queue_name=self.records_queue, 
                     routing_key=self.records_route, 
-                    message=json.dumps(record.to_dict(), default=str)
+                    message={ 'record_id', record.id }
                 )
 
                 redrive_count = count

--- a/etl-pipeline/processes/util/redrive_records.py
+++ b/etl-pipeline/processes/util/redrive_records.py
@@ -43,7 +43,7 @@ class RedriveRecordsProcess:
                 self.rabbitmq_manager.send_message_to_queue(
                     queue_name=self.records_queue, 
                     routing_key=self.records_route, 
-                    message={ 'record_id', record.id }
+                    message={ "source_id": record.source_id, "source": record.source }
                 )
 
                 redrive_count = count

--- a/etl-pipeline/tests/functional/processes/frbr/test_cluster_process.py
+++ b/etl-pipeline/tests/functional/processes/frbr/test_cluster_process.py
@@ -1,6 +1,6 @@
 import pytest
 from processes import ClusterProcess, RecordClusterer
-from model import Record, Item, Edition, Work
+from model import Record, Item, Edition, Work, RecordState
 
 def test_cluster_process(db_manager, unclustered_record_uuid):
     cluster_process = ClusterProcess('complete', None, None, unclustered_record_uuid, None)

--- a/etl-pipeline/tests/functional/processes/frbr/test_embellish_process.py
+++ b/etl-pipeline/tests/functional/processes/frbr/test_embellish_process.py
@@ -2,7 +2,7 @@ import pytest
 
 from processes import ClassifyProcess, CatalogProcess, RecordEmbellisher
 from managers import RedisManager
-from model import Record
+from model import Record, RecordState
 
 
 def test_embellish_record(db_manager, unembellished_record_uuid):

--- a/etl-pipeline/tests/functional/processes/frbr/test_record_pipeline.py
+++ b/etl-pipeline/tests/functional/processes/frbr/test_record_pipeline.py
@@ -27,7 +27,7 @@ def test_record_pipeline(db_manager, rabbitmq_manager: RabbitMQManager, unembell
     rabbitmq_manager.send_message_to_queue(
         queue_name=record_queue,
         routing_key=record_route,
-        message={ 'record_id': record.id }
+        message={ "source_id": record.source_id, "source": record.source }
     )
 
     sleep(1)

--- a/etl-pipeline/tests/functional/processes/frbr/test_record_pipeline.py
+++ b/etl-pipeline/tests/functional/processes/frbr/test_record_pipeline.py
@@ -27,7 +27,7 @@ def test_record_pipeline(db_manager, rabbitmq_manager: RabbitMQManager, unembell
     rabbitmq_manager.send_message_to_queue(
         queue_name=record_queue,
         routing_key=record_route,
-        message=json.dumps(record.to_dict(), default=str)
+        message={ 'record_id': record.id }
     )
 
     sleep(1)


### PR DESCRIPTION
when ingesting records, persist them with a new `state` value of `ingested`, and then send a smaller message to SQS, just containing the record id to stay under the SQS message size limit.

Note, I adapted the record buffer a bit here so that the ingestor could consume the buffered records as they get flushed out - I *could* instead replicate / extract the upsert logic in the record buffer into the ingestor, but this way was fastest.

## How to test
Run the loc ingest `python -m main -p LOCProcess -i complete -l 5`, observe the new records in the DB with the correct state, and the new messages in localstack SQS