### PR TITLE
fix: Handle null SQS visibility timeout

### DIFF
--- a/etl-pipeline/managers/sqs.py
+++ b/etl-pipeline/managers/sqs.py
@@ -72,13 +72,16 @@ class SQSManager:
         if not self.client:
             self.create_client()
         try:
-            response = self.client.receive_message(
-                QueueUrl=self.queue_url,
-                WaitTimeSeconds=self.wait_time_seconds,
-                MessageAttributeNames=["All"],
-                MaxNumberOfMessages=self.max_receive_count,
-                VisibilityTimeout=visibility_timeout,
-            )
+            receive_message_kwargs = {
+                "QueueUrl": self.queue_url,
+                "WaitTimeSeconds": self.wait_time_seconds,
+                "MessageAttributeNames": ["All"],
+                "MaxNumberOfMessages": self.max_receive_count,
+            }
+            if visibility_timeout:
+                receive_message_kwargs["VisibilityTimeout"] = visibility_timeout
+
+            response = self.client.receive_message(**receive_message_kwargs)
             return response["Messages"] if "Messages" in response else None
         except ClientError as e:
             logger.error(f"Failed to receive message from SQS: {e}")


### PR DESCRIPTION
In practice doesn't break anything since we always pass something in, but breaks the integration test, since boto3 frustratingly doesn't like an explicitly set `None`

## Describe your changes

## How to test
