### PR TITLE
NO-REF: Add record state filter when generating candidate pool

### DIFF
--- a/etl-pipeline/processes/candidate_record_finder.py
+++ b/etl-pipeline/processes/candidate_record_finder.py
@@ -5,7 +5,7 @@ from sqlalchemy.exc import DataError
 from managers import DBManager, RedisManager
 
 from .constants import CLUSTER_LOCK_KEY_PREFIX
-from model import Record
+from model import Record, RecordState
 from logger import create_log
 
 logger = create_log(__name__)
@@ -121,6 +121,7 @@ class CandidateRecordFinder:
                     .filter(~Record.id.in_(already_matched_record_ids))
                     .filter(Record.identifiers.overlap(id_batch))
                     .filter(Record.title.isnot(None))
+                    .filter(Record.state != RecordState.INGESTED.value)
                     .all()
                 )
                 

--- a/etl-pipeline/processes/candidate_record_finder.py
+++ b/etl-pipeline/processes/candidate_record_finder.py
@@ -2,6 +2,7 @@ import re
 from logging import Logger
 from typing import List, Set, Tuple, Optional, Any
 from sqlalchemy.exc import DataError
+from sqlalchemy import or_
 from managers import DBManager, RedisManager
 
 from .constants import CLUSTER_LOCK_KEY_PREFIX
@@ -121,7 +122,12 @@ class CandidateRecordFinder:
                     .filter(~Record.id.in_(already_matched_record_ids))
                     .filter(Record.identifiers.overlap(id_batch))
                     .filter(Record.title.isnot(None))
-                    .filter(Record.state != RecordState.INGESTED.value)
+                    .filter(
+                        or_(
+                            Record.state != RecordState.INGESTED.value,
+                            Record.state.is_(None)
+                        )
+                    )
                     .all()
                 )
                 

--- a/etl-pipeline/tests/conftest.py
+++ b/etl-pipeline/tests/conftest.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from unittest.mock import patch, MagicMock
 
 from processes import RecordClusterer
-from model import Collection, Edition, FileFlags, Item, Link, Part, Record, Work
+from model import Collection, Edition, FileFlags, Item, Link, Part, Record, RecordState, Work
 from model.postgres.item import ITEM_LINKS
 from logger import create_log
 from managers import DBManager, RabbitMQManager, RedisManager, S3Manager
@@ -145,6 +145,7 @@ def frbrized_record_data(db_manager, redis_manager, test_title, test_subject, te
         'title': test_title,
         'uuid': uuid4(),
         'frbr_status': 'complete',
+        'state': RecordState.EMBELLISHED.value,
         'cluster_status': False,
         "source": TEST_SOURCE,
         'authors': ['Ayan||true'],

--- a/etl-pipeline/tests/fixtures/generate_test_data.py
+++ b/etl-pipeline/tests/fixtures/generate_test_data.py
@@ -1,4 +1,5 @@
 import json
+from model import RecordState
 
 TEST_SOURCE = 'test_source'
 
@@ -6,6 +7,7 @@ def generate_test_data(
     title='test record',
     uuid=None,
     frbr_status='complete',
+    state=RecordState.EMBELLISHED.value,
     cluster_status=False,
     source=TEST_SOURCE,
     authors=['Test Author||true'],
@@ -28,6 +30,7 @@ def generate_test_data(
         'uuid': uuid,
         'frbr_status': frbr_status,
         'cluster_status': cluster_status,
+        'state': state,
         'source': source,
         'authors': authors,
         'languages': languages,


### PR DESCRIPTION
## Describe your changes
- We should only try to create candidate records if the state is past the ingestion step

## How to test
`make functional; make integration`
