### PR TITLE
NO-REF: Remove edition statement from kmeans pipeline

### DIFF
--- a/etl-pipeline/managers/kMeans.py
+++ b/etl-pipeline/managers/kMeans.py
@@ -70,23 +70,6 @@ class KMeansManager:
                     ]
                 ),
             ),
-            "edition": (
-                "edition",
-                Pipeline(
-                    [
-                        ("selector", FeatureSelector(key="edition")),
-                        (
-                            "tfidf",
-                            TfidfVectorizer(
-                                preprocessor=KMeansManager.pubProcessor,
-                                strip_accents="unicode",
-                                analyzer="char_wb",
-                                ngram_range=(1, 3),
-                            ),
-                        ),
-                    ]
-                ),
-            ),
             "pubDate": (
                 "pubDate",
                 Pipeline(
@@ -101,7 +84,6 @@ class KMeansManager:
         pipelineWeights = {
             "place": 1.0,
             "publisher": 1.0,
-            "edition": 1.0,
             "pubDate": 1.75,
         }
 
@@ -149,7 +131,6 @@ class KMeansManager:
                         "place": spatialData or "",
                         "publisher": publisherData,
                         "pubDate": dateData,
-                        "edition": self.getEditionStatement(i.has_version),
                         "uuid": i.uuid,
                     }
                 )
@@ -235,19 +216,6 @@ class KMeansManager:
             pubs.append(publisher.strip(",. []").lower())
 
         return ", ".join(pubs)
-
-    @classmethod
-    def getEditionStatement(cls, hasVersion):
-        if not hasVersion:
-            return ""
-        for version in hasVersion:
-            try:
-                statement, _ = tuple(version.split("|"))
-                return statement
-            except ValueError:
-                pass
-
-        return ""
 
     def generateClusters(self):
         try:

--- a/etl-pipeline/tests/unit/test_kmeans_manager.py
+++ b/etl-pipeline/tests/unit/test_kmeans_manager.py
@@ -141,7 +141,6 @@ class TestKMeansModel(object):
         mockPipeline.side_effect = [
             "placePipe",
             "pubPipe",
-            "edPipe",
             "datePipe",
             "mainPipe",
         ]
@@ -184,8 +183,6 @@ class TestKMeansModel(object):
             (None, {}, None),
             ("place2", {"century": 19, "decade": 5, "year": 1}, None),
         ]
-        mockGetEd = mocker.patch.object(KMeansManager, "getEditionStatement")
-        mockGetEd.side_effect = ["ed1", "ed2", False]
 
         testModel.createDF()
         assert isinstance(testModel.df, pd.DataFrame)
@@ -199,7 +196,6 @@ class TestKMeansModel(object):
         ]
         mockGetData = mocker.patch.object(KMeansManager, "getInstanceData")
         mockGetData.side_effect = [(i, i, i) for i in range(1200)]
-        mocker.patch.object(KMeansManager, "getEditionStatement")
 
         testModel.createDF()
 
@@ -211,7 +207,6 @@ class TestKMeansModel(object):
         ]
         mockGetData = mocker.patch.object(KMeansManager, "getInstanceData")
         mockGetData.side_effect = [(i, i, i) for i in range(750)]
-        mocker.patch.object(KMeansManager, "getEditionStatement")
 
         testModel.createDF()
 
@@ -223,7 +218,6 @@ class TestKMeansModel(object):
         ]
         mockGetData = mocker.patch.object(KMeansManager, "getInstanceData")
         mockGetData.side_effect = [(i, i, i) for i in range(350)]
-        mocker.patch.object(KMeansManager, "getEditionStatement")
 
         testModel.createDF()
 
@@ -288,21 +282,6 @@ class TestKMeansModel(object):
         outPublisher = KMeansManager.getPublishers(None)
 
         assert outPublisher == ""
-
-    def test_getEditionStatement_value_present(self, mocker):
-        edStmt = KMeansManager.getEditionStatement(["edition|1"])
-
-        assert edStmt == "edition"
-
-    def test_getEditionStatement_no_value(self, mocker):
-        edStmt = KMeansManager.getEditionStatement(None)
-
-        assert edStmt == ""
-
-    def test_getEditionStatement_empty_array(self, mocker):
-        edStmt = KMeansManager.getEditionStatement([])
-
-        assert edStmt == ""
 
     def test_generateClusters_multiple(self, mocker, testModel):
         mockGetK = mocker.patch.object(KMeansManager, "getK")


### PR DESCRIPTION
## Describe your changes
- 99% of records do not have an edition statement (_has_version) 
- As such, let's remove the edition statement from the kmeans pipeline to see if it helps with performance 

## How to test
`make unit; make functional; make integration`