### PR TITLE
NO-REF: First pass - move out extraneous kmeans logic

### DIFF
--- a/etl-pipeline/managers/kMeans.py
+++ b/etl-pipeline/managers/kMeans.py
@@ -13,6 +13,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.exceptions import ConvergenceWarning
 
 from logger import create_log
+from parsers import YearParser, get_publication_date_object
 
 logger = create_log(__name__)
 
@@ -173,53 +174,10 @@ class KMeansManager:
     @classmethod
     def getInstanceData(cls, instance):
         spatial = instance.spatial
-        date = cls.getPubDateObject(instance.dates)
+        date = get_publication_date_object(instance.dates)
         publisher = cls.getPublishers(instance.publisher)
 
         return (spatial, date, publisher)
-
-    @classmethod
-    def getPubDateObject(cls, dates):
-        if dates is None or len(dates) < 1:
-            return {}
-
-        pubYears = {}
-
-        for d in dates:
-            try:
-                date, dateType = tuple(d.split("|"))
-
-                dateGroups = re.search(r"([\d\-\?]+)", date)
-
-                dateStr = dateGroups.group(1)
-
-                startYear, endYear = ("", "")
-
-                if re.match(r"[0-9]{4}-[0-9]{4}", dateStr):
-                    rangeMatches = re.match(r"([0-9]{4})-([0-9]{4})", dateStr)
-                    startYear = rangeMatches.group(1)
-                    endYear = rangeMatches.group(2)
-                elif re.match(r"[0-9]{4}-[0-9]{2}-[0-9]{2}", dateStr):
-                    year, _, _ = tuple(dateStr.split("-"))
-                    startYear, endYear = (year, year)
-                elif re.match(r"[0-9]{4}-[0-9]{2}", dateStr):
-                    year, _ = tuple(dateStr.split("-"))
-                    startYear, endYear = (year, year)
-                else:
-                    startYear, endYear = (dateStr, dateStr)
-
-                yearParser = YearObject(startYear, endYear)
-                yearParser.setYearComponents()
-                pubYears[dateType] = dict(yearParser)
-            except (ValueError, AttributeError, IndexError) as e:
-                logger.warning("Unable to parse date {}".format(d))
-
-        for datePref in ["copyright_date", "publication_date", "issued"]:
-            if datePref in pubYears.keys():
-                return pubYears[datePref]
-
-        logger.debug("Unable to locate publication date")
-        return {}
 
     @classmethod
     def getPublishers(cls, publishers):
@@ -342,75 +300,10 @@ class KMeansManager:
             yearEds = defaultdict(list)
             logger.debug("Parsing cluster {}".format(clust))
             for ed in self.clusters[clust]:
-                editionYear = YearObject.convertYearDictToStr(ed.iloc[0]["pubDate"])
+                editionYear = YearParser.convertYearDictToStr(ed.iloc[0]["pubDate"])
                 logger.debug("Adding instance to {} edition".format(editionYear))
                 yearEds[editionYear].append(ed.iloc[0]["uuid"])
             eds.extend([(year, data) for year, data in yearEds.items()])
             eds.sort(key=lambda x: x[0])
 
         return eds
-
-
-class YearObject:
-    def __init__(self, start, end):
-        self.start = str(start)
-        self.end = str(end)
-        self.century = [None, None]
-        self.decade = [None, None]
-        self.year = [None, None]
-
-    def setYearComponents(self):
-        self.setCentury()
-        self.setDecade()
-        self.setYear()
-
-    def setCentury(self):
-        self.century[0] = int(self.start[:2])
-
-        if len(self.end) > 2:
-            self.century[1] = int(self.end[:2])
-
-    def setDecade(self):
-        if self.start[2] not in ["-", "?"]:
-            self.decade[0] = int(self.start[2])
-
-        if len(self.end) > 2 and self.end[2] not in ["-", "?"]:
-            self.decade[1] = int(self.end[2])
-
-    def setYear(self):
-        if self.start[3] not in ["-", "?"]:
-            self.year[0] = int(self.start[3])
-
-        if len(self.end) > 2 and self.end[3] not in ["-", "?"]:
-            self.year[1] = int(self.end[3])
-
-    def __iter__(self):
-        for key in ["century", "decade", "year"]:
-            yearComp = getattr(self, key)
-
-            if yearComp[0] is not None:
-                yield "{}Start".format(key), yearComp[0]
-
-            if yearComp[1] is not None:
-                yield "{}End".format(key), yearComp[1]
-
-    @staticmethod
-    def convertYearDictToStr(yearDict):
-        startYear = YearObject.getYearStr(yearDict, "Start")
-        endYear = YearObject.getYearStr(yearDict, "End")
-
-        return (
-            "{}-{}".format(startYear, endYear)
-            if endYear and endYear != startYear
-            else str(startYear)
-        )
-
-    @staticmethod
-    def getYearStr(yearDict, yearType):
-        century = yearDict.get("century{}".format(yearType), None)
-        decade = yearDict.get("decade{}".format(yearType), None)
-        year = yearDict.get("year{}".format(yearType), None)
-
-        return "".join(
-            map(lambda x: str(x) if x is not None else "x", [century, decade, year])
-        )

--- a/etl-pipeline/parsers/__init__.py
+++ b/etl-pipeline/parsers/__init__.py
@@ -1,0 +1,2 @@
+from .year_parser import YearParser
+from .date_parser import get_publication_date_object

--- a/etl-pipeline/parsers/date_parser.py
+++ b/etl-pipeline/parsers/date_parser.py
@@ -1,0 +1,45 @@
+import re
+
+from .year_parser import YearParser
+
+
+def get_publication_date_object(dates: list[str]) -> dict:
+    if dates is None or len(dates) < 1:
+        return {}
+
+    pubYears = {}
+
+    for d in dates:
+        try:
+            date, dateType = tuple(d.split("|"))
+
+            dateGroups = re.search(r"([\d\-\?]+)", date)
+
+            dateStr = dateGroups.group(1)
+
+            startYear, endYear = ("", "")
+
+            if re.match(r"[0-9]{4}-[0-9]{4}", dateStr):
+                rangeMatches = re.match(r"([0-9]{4})-([0-9]{4})", dateStr)
+                startYear = rangeMatches.group(1)
+                endYear = rangeMatches.group(2)
+            elif re.match(r"[0-9]{4}-[0-9]{2}-[0-9]{2}", dateStr):
+                year, _, _ = tuple(dateStr.split("-"))
+                startYear, endYear = (year, year)
+            elif re.match(r"[0-9]{4}-[0-9]{2}", dateStr):
+                year, _ = tuple(dateStr.split("-"))
+                startYear, endYear = (year, year)
+            else:
+                startYear, endYear = (dateStr, dateStr)
+
+            yearParser = YearParser(startYear, endYear)
+            yearParser.setYearComponents()
+            pubYears[dateType] = dict(yearParser)
+        except (ValueError, AttributeError, IndexError) as e:
+            pass
+
+    for datePref in ["copyright_date", "publication_date", "issued"]:
+        if datePref in pubYears.keys():
+            return pubYears[datePref]
+
+    return {}

--- a/etl-pipeline/parsers/year_parser.py
+++ b/etl-pipeline/parsers/year_parser.py
@@ -1,0 +1,63 @@
+class YearParser:
+    def __init__(self, start, end):
+        self.start = str(start)
+        self.end = str(end)
+        self.century = [None, None]
+        self.decade = [None, None]
+        self.year = [None, None]
+
+    def setYearComponents(self):
+        self.setCentury()
+        self.setDecade()
+        self.setYear()
+
+    def setCentury(self):
+        self.century[0] = int(self.start[:2])
+
+        if len(self.end) > 2:
+            self.century[1] = int(self.end[:2])
+
+    def setDecade(self):
+        if self.start[2] not in ["-", "?"]:
+            self.decade[0] = int(self.start[2])
+
+        if len(self.end) > 2 and self.end[2] not in ["-", "?"]:
+            self.decade[1] = int(self.end[2])
+
+    def setYear(self):
+        if self.start[3] not in ["-", "?"]:
+            self.year[0] = int(self.start[3])
+
+        if len(self.end) > 2 and self.end[3] not in ["-", "?"]:
+            self.year[1] = int(self.end[3])
+
+    def __iter__(self):
+        for key in ["century", "decade", "year"]:
+            yearComp = getattr(self, key)
+
+            if yearComp[0] is not None:
+                yield "{}Start".format(key), yearComp[0]
+
+            if yearComp[1] is not None:
+                yield "{}End".format(key), yearComp[1]
+
+    @staticmethod
+    def convertYearDictToStr(yearDict):
+        startYear = YearParser.getYearStr(yearDict, "Start")
+        endYear = YearParser.getYearStr(yearDict, "End")
+
+        return (
+            "{}-{}".format(startYear, endYear)
+            if endYear and endYear != startYear
+            else str(startYear)
+        )
+
+    @staticmethod
+    def getYearStr(yearDict, yearType):
+        century = yearDict.get("century{}".format(yearType), None)
+        decade = yearDict.get("decade{}".format(yearType), None)
+        year = yearDict.get("year{}".format(yearType), None)
+
+        return "".join(
+            map(lambda x: str(x) if x is not None else "x", [century, decade, year])
+        )

--- a/etl-pipeline/tests/unit/test_kmeans_manager.py
+++ b/etl-pipeline/tests/unit/test_kmeans_manager.py
@@ -1,7 +1,8 @@
 import pandas as pd
 import pytest
 
-from managers.kMeans import KMeansManager, YearObject
+from managers.kMeans import KMeansManager
+from parsers import YearParser, get_publication_date_object
 
 
 class TestKMeansModel(object):
@@ -230,48 +231,49 @@ class TestKMeansModel(object):
         assert testModel.maxK == int(350 * (4 / 9))
 
     def test_getPubDateObject_range(self, mocker, TestYear):
-        mockParser = mocker.patch("managers.kMeans.YearObject")
+        mockParser = mocker.patch("parsers.date_parser.YearParser")
         mockParser.side_effect = [TestYear(20, 0, 0), TestYear(19, 0, 0)]
 
         mockDates = ["2000|other_date", "1900-1901|publication_date"]
-        outYear = KMeansManager.getPubDateObject(mockDates)
+        outYear = get_publication_date_object(mockDates)
 
         assert outYear == {"century": 19, "decade": 0, "year": 0}
 
     def test_getPubDateObject_year_only(self, mocker, TestYear):
-        mockParser = mocker.patch("managers.kMeans.YearObject")
+        mockParser = mocker.patch("parsers.date_parser.YearParser")
         mockParser.side_effect = [TestYear(20, 0, 0), TestYear(19, 0, 0)]
 
         mockDates = ["2000|other_date", "1900|publication_date"]
-        outYear = KMeansManager.getPubDateObject(mockDates)
+        outYear = get_publication_date_object(mockDates)
 
         assert outYear == {"century": 19, "decade": 0, "year": 0}
 
     def test_getPubDateObject_full_date(self, mocker, TestYear):
-        mockParser = mocker.patch("managers.kMeans.YearObject")
+        mockParser = mocker.patch("parsers.date_parser.YearParser")
         mockParser.side_effect = [TestYear(20, 0, 0), TestYear(19, 0, 0)]
 
         mockDates = ["2000-12-01|other_date", "1900-01-01|publication_date"]
-        outYear = KMeansManager.getPubDateObject(mockDates)
+        outYear = get_publication_date_object(mockDates)
+        print(outYear)
 
         assert outYear == {"century": 19, "decade": 0, "year": 0}
 
     def test_getPubDateFloat_neither(self, mocker):
-        mocker.patch("managers.kMeans.YearObject")
+        mocker.patch("parsers.date_parser.YearParser")
         mockDates = ["2000|other_date", "1900-1901|pub_date"]
-        outYear = KMeansManager.getPubDateObject(mockDates)
+        outYear = get_publication_date_object(mockDates)
         assert outYear == {}
 
     def test_getPubDateFloat_no_dates(self, mocker):
-        outYear = KMeansManager.getPubDateObject([])
+        outYear = get_publication_date_object([])
         assert outYear == {}
 
     def test_getPubDateFloat_bad_value(self, mocker):
-        outYear = KMeansManager.getPubDateObject(["2000"])
+        outYear = get_publication_date_object(["2000"])
         assert outYear == {}
 
     def test_getPubDateFloat_bad_string_value(self, mocker):
-        outYear = KMeansManager.getPubDateObject(["test|date"])
+        outYear = get_publication_date_object(["test|date"])
         assert outYear == {}
 
     def test_getPublishers_clean(self, mocker):
@@ -361,7 +363,7 @@ class TestKMeansModel(object):
         mockPipeline.fit_predict.assert_called_once()
 
     def test_parseEditions(self, testModel, mocker):
-        mockConvert = mocker.patch.object(YearObject, "convertYearDictToStr")
+        mockConvert = mocker.patch.object(YearParser, "convertYearDictToStr")
         mockConvert.side_effect = [1900, 1900, 2000, 1950]
         outEditions = testModel.parseEditions()
         assert len(outEditions) == 3

--- a/etl-pipeline/tests/unit/test_kmeans_manager.py
+++ b/etl-pipeline/tests/unit/test_kmeans_manager.py
@@ -254,7 +254,6 @@ class TestKMeansModel(object):
 
         mockDates = ["2000-12-01|other_date", "1900-01-01|publication_date"]
         outYear = get_publication_date_object(mockDates)
-        print(outYear)
 
         assert outYear == {"century": 19, "decade": 0, "year": 0}
 

--- a/etl-pipeline/tests/unit/test_year_parser.py
+++ b/etl-pipeline/tests/unit/test_year_parser.py
@@ -1,12 +1,12 @@
 import pytest
 
-from managers.kMeans import YearObject
+from parsers import YearParser
 
 
-class TestYearObject:
+class TestYearParser:
     @pytest.fixture
     def testObject(self):
-        return YearObject(1900, 2000)
+        return YearParser(1900, 2000)
 
     def test_initializer(self, testObject):
         assert testObject.start == "1900"
@@ -17,7 +17,7 @@ class TestYearObject:
 
     def test_setYearComponents(self, testObject, mocker):
         objectMocks = mocker.patch.multiple(
-            YearObject,
+            YearParser,
             setCentury=mocker.DEFAULT,
             setDecade=mocker.DEFAULT,
             setYear=mocker.DEFAULT,
@@ -63,21 +63,21 @@ class TestYearObject:
         assert testObject.year == [0, None]
 
     def test_convertYearDictToStr_start_end(self, mocker):
-        mockGetYear = mocker.patch.object(YearObject, "getYearStr")
+        mockGetYear = mocker.patch.object(YearParser, "getYearStr")
         mockGetYear.side_effect = [1900, 2000]
 
-        assert YearObject.convertYearDictToStr("mockDict") == "1900-2000"
+        assert YearParser.convertYearDictToStr("mockDict") == "1900-2000"
 
     def test_convertYearDictToStr_start_only(self, mocker):
-        mockGetYear = mocker.patch.object(YearObject, "getYearStr")
+        mockGetYear = mocker.patch.object(YearParser, "getYearStr")
         mockGetYear.side_effect = [1900, None]
 
-        assert YearObject.convertYearDictToStr("mockDict") == "1900"
+        assert YearParser.convertYearDictToStr("mockDict") == "1900"
 
     def test_getYearStr(self):
         testYearDict = {"centuryTest": 19, "decadeTest": 9, "yearTest": None}
 
-        assert YearObject.getYearStr(testYearDict, "Test") == "199x"
+        assert YearParser.getYearStr(testYearDict, "Test") == "199x"
 
     def test_iter_for_dict(self, testObject):
         testObject.century = [19, 20]


### PR DESCRIPTION
## Describe your changes
- First of a few passes to move out clean up the kmeans logic\
- Moves out the year and date parsing logic to separate files/classes

## How to test
`make unit`