### PR TITLE
SFR-2687 Initialize conversion for new books

### DIFF
--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -21,26 +21,24 @@ class GRINConversion:
     def run_process(self):
         self.db_manager.create_session()
 
-        self.acquire_new_books()
+        self.acquire_and_convert_new_books()
 
         self.process_converted_books()
 
         self.db_manager.session.close()
-
-    def acquire_new_books(self):
+    
+    def acquire_and_convert_new_books(self):
         data = self.client.acquired_today()
         if len(data) > 1:
-            dataframe = self.transform_scraped_data(data)
+            new_books_df = self.transform_scraped_data(data)
 
-            grin_converted_barcodes = dataframe.query('State == "CONVERTED"')
-            self.save_barcodes(grin_converted_barcodes["Barcode"], GRINState.CONVERTED)
+            new_barcodes= new_books_df.query('State == "NEW"')
+            converted_data = self.client.convert(new_barcodes["Barcode"])
+            converted_df = self.transform_scraped_data(converted_data)
 
-            new_barcodes = dataframe.query('State == "NEW"')
-            self.save_barcodes(new_barcodes["Barcode"], GRINState.PENDING_CONVERSION)
+            converted_barcodes = converted_df.query('Status == "Success"')
 
-    def convert(self):
-        # Add conversion step
-        pass
+            self.save_barcodes(converted_barcodes["Barcode"], GRINState.CONVERTING)
 
     def convert_backfills(self):
         # initialize conversion the new books, and update the DB

--- a/etl-pipeline/services/grin/grin_client.py
+++ b/etl-pipeline/services/grin/grin_client.py
@@ -12,6 +12,7 @@ import json
 from ..ssm_service import SSMService
 from pdb import set_trace
 
+BATCH_LIMIT = 1000
 
 class GRINClient(object):
     def __init__(self):
@@ -43,6 +44,30 @@ class GRINClient(object):
         if response.status_code != 200:
             raise IOError("%s got %s unexpectedly" % (url, response.status_code))
         return response.content
+    
+    def convert(self, barcodes):
+        # Ask Google to move some barcodes from the "Available" state to "In-Process"
+        # Response to process will always be a 200 and the content will a table of Barcodes and corresponding Statuses.
+        # For each barcode, a status will be returned of either 
+        # "Success", "Already being converted" "Other error", "Not allowed to be downloaded"
+        response = []
+        
+        if len(barcodes) >= BATCH_LIMIT:
+            chunked_barcodes = [barcodes[i:i + BATCH_LIMIT] for i in range(0, len(barcodes), BATCH_LIMIT)]
+        else:
+            chunked_barcodes = [barcodes]
+
+        for chunk in chunked_barcodes:
+            barcodes = "\n".join(chunk)
+            raw_response = self.session.request("POST", self._url("_process"), data=barcodes)
+            sanitized_response = raw_response.content.decode("utf8").split("\n")
+            if len(response) > 0:
+                # Remove headers if this is not the first request
+                response += sanitized_response[1:]
+            else:
+                response = sanitized_response
+
+        return response
 
     def acquired_today(self, *args, **kwargs):
         # For GRIN queries, range start is inclusive but the range end is exclusive.
@@ -89,9 +114,3 @@ class GRINClient(object):
     def download(self, filename, *args, **kwargs):
         # Download desired book
         return self.get(filename, os.path.join("books", filename), *args, **kwargs)
-
-    def please_process(self, barcodes):
-        # Ask Google to move some barcodes from the "Available" state to "In-Process"
-        if isinstance(barcodes, list):
-            barcodes = "\n".join(barcodes)
-        self.session.request("POST", self._url("_process"), data=barcodes)


### PR DESCRIPTION
## Describe your changes
This PR initializes conversion for all new GRIN books acquired in the past day. I changed the flow in the conversion script to kick off conversion immediately for all new books. I also refactored the `please_process` method to be `convert` and added some batch processing since there is around a 1000 batch size limit for conversion in GRIN.