### PR TITLE
SFR-2702 Initiate conversion for backfilled books

### DIFF
--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -34,7 +34,7 @@ class GRINConversion:
 
     def acquire_and_convert_new_books(self):
         data = self.client.acquired_today()
-        if len(data) > 1:
+        if len(data) > 2:
             new_books_df = self.transform_scraped_data(data)
             new_barcodes = new_books_df.query('State == "NEW"')
 

--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -17,21 +17,15 @@ CHUNK_SIZE = 1000
 class GRINConversion:
     def __init__(self):
         self.client = GRINClient()
-        self.db_manager = DBManager(
-            user="localuser",
-            pswd="localpsql",
-            host="localhost",
-            port="5432",
-            db="drb_test_db",
-        )
+        self.db_manager = DBManager()
         self.logger = create_log(__name__)
 
     def run_process(self, backfill=False):
         self.db_manager.create_session()
 
-        # self.acquire_and_convert_new_books()
+        self.acquire_and_convert_new_books()
 
-        # self.process_converted_books()
+        self.process_converted_books()
 
         if backfill:
             self.convert_backfills(CHUNK_SIZE)

--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -3,7 +3,9 @@
 
 from .grin_client import GRINClient
 import pandas as pd
+from sqlalchemy import select, update
 from model import GRINState, GRINStatus, Record, FRBRStatus
+from datetime import datetime
 from typing import List, Iterator
 from managers import DBManager
 from uuid import uuid4
@@ -11,19 +13,21 @@ from logger import create_log
 
 CHUNK_SIZE = 1000
 
-
 class GRINConversion:
     def __init__(self):
         self.client = GRINClient()
         self.db_manager = DBManager()
         self.logger = create_log(__name__)
 
-    def run_process(self):
+    def run_process(self, backfill = False):
         self.db_manager.create_session()
 
         self.acquire_and_convert_new_books()
 
         self.process_converted_books()
+
+        if backfill:
+            self.convert_backfills(CHUNK_SIZE)
 
         self.db_manager.session.close()
 
@@ -31,18 +35,32 @@ class GRINConversion:
         data = self.client.acquired_today()
         if len(data) > 1:
             new_books_df = self.transform_scraped_data(data)
-
             new_barcodes = new_books_df.query('State == "NEW"')
-            converted_data = self.client.convert(new_barcodes["Barcode"])
-            converted_df = self.transform_scraped_data(converted_data)
 
-            converted_barcodes = converted_df.query('Status == "Success"')
+            converting_barcodes = self.convert_barcodes(new_barcodes["Barcode"])
 
-            self.save_barcodes(converted_barcodes["Barcode"], GRINState.CONVERTING)
+            self.save_barcodes(converting_barcodes, GRINState.CONVERTING)
 
-    def convert_backfills(self):
-        # initialize conversion the new books, and update the DB
-        pass
+    def convert_backfills(self, batch_size):
+        backfill_query = select(GRINStatus.barcode).where(
+            GRINStatus.state == GRINState.PENDING_CONVERSION.value,
+        ).where(GRINStatus.date_created <= datetime(1991, 8, 25)).limit(CHUNK_SIZE)
+        
+        backfilled_barcodes = self.db_manager.session.execute(backfill_query).scalars().all()
+        converting_barcodes = self.convert_barcodes(backfilled_barcodes)
+        try:
+            update_barcodes = (update(GRINStatus).filter(GRINStatus.barcode.in_(converting_barcodes)).values(state = GRINState.CONVERTING.value))
+            self.db_manager.session.execute(update_barcodes)
+            self.db_manager.commit_changes()
+        except:
+            self.db_manager.session.rollback()
+            self.logger.exception(f"Failed to update the following records: {converting_barcodes}")
+
+    def convert_barcodes(self, barcodes):
+        converted_data = self.client.convert(barcodes)
+        converted_df = self.transform_scraped_data(converted_data)
+        converted_barcodes = converted_df.query('Status == "Success"')
+        return converted_barcodes["Barcode"]
 
     def save_barcodes(self, barcodes, state):
         if len(barcodes) > 0:
@@ -63,8 +81,8 @@ class GRINConversion:
                 self.db_manager.session.add_all(records)
                 self.db_manager.commit_changes()
             except Exception:
-                self.logger.exception("Failed to add the following records:")
-                raise
+                self.db_manager.session.rollback()
+                self.logger.exception(f"Failed to update the following records: {chunked_barcodes}")
 
     def process_converted_books(self):
         converted_barcodes = self.client.converted()
@@ -108,4 +126,4 @@ def chunk(xs: Iterator, size: int) -> Iterator[list]:
 
 if __name__ == "__main__":
     grin_conversion = GRINConversion()
-    grin_conversion.run_process()
+    grin_conversion.run_process(backfill=True)

--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -26,13 +26,13 @@ class GRINConversion:
         self.process_converted_books()
 
         self.db_manager.session.close()
-    
+
     def acquire_and_convert_new_books(self):
         data = self.client.acquired_today()
         if len(data) > 1:
             new_books_df = self.transform_scraped_data(data)
 
-            new_barcodes= new_books_df.query('State == "NEW"')
+            new_barcodes = new_books_df.query('State == "NEW"')
             converted_data = self.client.convert(new_barcodes["Barcode"])
             converted_df = self.transform_scraped_data(converted_data)
 

--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -49,7 +49,7 @@ class GRINConversion:
                 GRINStatus.state == GRINState.PENDING_CONVERSION.value,
             )
             .where(GRINStatus.date_created <= datetime(1991, 8, 25))
-            .limit(CHUNK_SIZE)
+            .limit(batch_size)
         )
 
         backfilled_barcodes = (

--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -21,26 +21,24 @@ class GRINConversion:
     def run_process(self):
         self.db_manager.create_session()
 
-        self.acquire_new_books()
+        self.acquire_and_convert_new_books()
 
         self.process_converted_books()
 
         self.db_manager.session.close()
-
-    def acquire_new_books(self):
+    
+    def acquire_and_convert_new_books(self):
         data = self.client.acquired_today()
         if len(data) > 1:
-            dataframe = self.transform_scraped_data(data)
+            new_books_df = self.transform_scraped_data(data)
 
-            grin_converted_barcodes = dataframe.query('State == "CONVERTED"')
-            self.save_barcodes(grin_converted_barcodes["Barcode"], GRINState.CONVERTED)
+            new_barcodes= new_books_df.query('State == "NEW"')
+            converted_data = self.client.convert(new_barcodes["Barcode"])
+            converted_df = self.transform_scraped_data(converted_data)
 
-            new_barcodes = dataframe.query('State == "NEW"')
-            self.save_barcodes(new_barcodes["Barcode"], GRINState.PENDING_CONVERSION)
+            converted_barcodes = converted_df.query('Status == "Success"')
 
-    def convert(self):
-        # Add conversion step
-        pass
+            self.save_barcodes(converted_barcodes["Barcode"], GRINState.CONVERTING)
 
     def convert_backfills(self):
         # initialize conversion the new books, and update the DB

--- a/etl-pipeline/services/grin/grin_client.py
+++ b/etl-pipeline/services/grin/grin_client.py
@@ -93,30 +93,23 @@ class GRINClient(object):
         return data
 
     def _for_state(self, state, *args, **kwargs):
-        # Which books are in the given state?
         data = self.get("_%s?format=text" % state, *args, **kwargs)
         return data.decode("utf8").strip().split("\n")
 
-    def available(self, *args, **kwargs):
-        # Which barcodes are available for conversion?
+    def available_for_conversion(self, *args, **kwargs):
         return self._for_state("available", *args, **kwargs)
 
     def in_process(self, *args, **kwargs):
-        # Which barcodes are being converted?
         return self._for_state("in_process", *args, **kwargs)
 
     def converted(self, *args, **kwargs):
-        # What are the filenames of files that have been converted?
         return self._for_state("converted", *args, **kwargs)
 
-    def failed(self, *args, **kwargs):
-        # Which barcodes failed conversion?
+    def failed_conversion(self, *args, **kwargs):
         return self._for_state("failed", *args, **kwargs)
 
     def all_books(self, *args, **kwargs):
-        # Get barcodes for all books in whatever state.
         return self._for_state("all_books", *args, **kwargs)
 
     def download(self, filename, *args, **kwargs):
-        # Download desired book
         return self.get(filename, os.path.join("books", filename), *args, **kwargs)

--- a/etl-pipeline/services/grin/grin_client.py
+++ b/etl-pipeline/services/grin/grin_client.py
@@ -14,6 +14,7 @@ from pdb import set_trace
 
 BATCH_LIMIT = 1000
 
+
 class GRINClient(object):
     def __init__(self):
         self.creds = self.load_creds()
@@ -44,22 +45,27 @@ class GRINClient(object):
         if response.status_code != 200:
             raise IOError("%s got %s unexpectedly" % (url, response.status_code))
         return response.content
-    
+
     def convert(self, barcodes):
         # Ask Google to move some barcodes from the "Available" state to "In-Process"
         # Response to process will always be a 200 and the content will a table of Barcodes and corresponding Statuses.
-        # For each barcode, a status will be returned of either 
+        # For each barcode, a status will be returned of either
         # "Success", "Already being converted" "Other error", "Not allowed to be downloaded"
         response = []
-        
+
         if len(barcodes) >= BATCH_LIMIT:
-            chunked_barcodes = [barcodes[i:i + BATCH_LIMIT] for i in range(0, len(barcodes), BATCH_LIMIT)]
+            chunked_barcodes = [
+                barcodes[i : i + BATCH_LIMIT]
+                for i in range(0, len(barcodes), BATCH_LIMIT)
+            ]
         else:
             chunked_barcodes = [barcodes]
 
         for chunk in chunked_barcodes:
             barcodes = "\n".join(chunk)
-            raw_response = self.session.request("POST", self._url("_process"), data=barcodes)
+            raw_response = self.session.request(
+                "POST", self._url("_process"), data=barcodes
+            )
             sanitized_response = raw_response.content.decode("utf8").split("\n")
             if len(response) > 0:
                 # Remove headers if this is not the first request

--- a/etl-pipeline/services/grin/grin_client.py
+++ b/etl-pipeline/services/grin/grin_client.py
@@ -12,6 +12,7 @@ import json
 from ..ssm_service import SSMService
 from pdb import set_trace
 
+BATCH_LIMIT = 1000
 
 class GRINClient(object):
     def __init__(self):
@@ -43,6 +44,30 @@ class GRINClient(object):
         if response.status_code != 200:
             raise IOError("%s got %s unexpectedly" % (url, response.status_code))
         return response.content
+    
+    def convert(self, barcodes):
+        # Ask Google to move some barcodes from the "Available" state to "In-Process"
+        # Response to process will always be a 200 and the content will a table of Barcodes and corresponding Statuses.
+        # For each barcode, a status will be returned of either 
+        # "Success", "Already being converted" "Other error", "Not allowed to be downloaded"
+        response = []
+        
+        if len(barcodes) >= BATCH_LIMIT:
+            chunked_barcodes = [barcodes[i:i + BATCH_LIMIT] for i in range(0, len(barcodes), BATCH_LIMIT)]
+        else:
+            chunked_barcodes = [barcodes]
+
+        for chunk in chunked_barcodes:
+            barcodes = "\n".join(chunk)
+            raw_response = self.session.request("POST", self._url("_process"), data=barcodes)
+            sanitized_response = raw_response.content.decode("utf8").split("\n")
+            if len(response) > 0:
+                # Remove headers if this is not the first request
+                response += sanitized_response[1:]
+            else:
+                response = sanitized_response
+
+        return response
 
     def acquired_today(self, *args, **kwargs):
         # For GRIN queries, range start is inclusive but the range end is exclusive.
@@ -89,9 +114,3 @@ class GRINClient(object):
     def download(self, filename, *args, **kwargs):
         # Download desired book
         return self.get(filename, os.path.join("books", filename), *args, **kwargs)
-
-    def please_process(self, barcodes):
-        # Ask Google to move some barcodes from the "Available" state to "In-Process"
-        if isinstance(barcodes, list):
-            barcodes = "\n".join(barcodes)
-        self.session.request("POST", self._url("_process"), data=barcodes)

--- a/etl-pipeline/services/grin/util.py
+++ b/etl-pipeline/services/grin/util.py
@@ -1,4 +1,3 @@
-
 from typing import Iterator
 
 
@@ -14,4 +13,3 @@ def chunk(xs: Iterator, size: int) -> Iterator[list]:
                 yield chunk
 
             break
-


### PR DESCRIPTION
## Describe your changes
This PR adds converting a batch of backfilled books to the daily conversion script. Specifically, it grabs a batch of relevant backfilled books, kicks off conversion for those, and updates the records in the database.

## How to test
You can test this by having some barcodes that are pending_conversion in your DB with a date of 8-24-1991. Comment out line 26 and 28 to isolate the backfill functionality. Run the file and you can check that conversion is kicked off in GRIN for those barcodes and the DB has been updated accordingly.