### PR TITLE
NO-REF: Remove file extension

### DIFF
--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -81,6 +81,7 @@ class GRINConversion:
                     update_barcodes = (
                         update(GRINStatus)
                         .filter(GRINStatus.barcode.in_(stripped_barcodes))
+                        .filter(GRINStatus.state != GRINState.DOWNLOADED.value)
                         .values(state=GRINState.CONVERTED.value)
                     )
                     self.db_manager.session.execute(update_barcodes)

--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -72,6 +72,7 @@ class GRINConversion:
         if len(converted_barcodes) > 0:
             for barcode in converted_barcodes:
                 try:
+                    barcode = barcode.split(".", 1)[0] # converted file name has the following pattern 1234.tar.gz.gpg
                     self.db_manager.session.query(GRINStatus).filter(
                         GRINStatus.barcode == f"{barcode}",
                         GRINStatus.state != GRINState.DOWNLOADED.value,

--- a/etl-pipeline/services/grin/grin_client.py
+++ b/etl-pipeline/services/grin/grin_client.py
@@ -105,7 +105,7 @@ class GRINClient(object):
         # Which barcodes are being converted?
         return self._for_state("in_process", *args, **kwargs)
 
-    def converted(self, *args, **kwargs):
+    def converted_filenames(self, *args, **kwargs):
         # What are the filenames of files that have been converted?
         return self._for_state("converted", *args, **kwargs)
 


### PR DESCRIPTION
## Describe your changes

The converted API returns a list of barcodes with file extension, we need to strip that since we only store the barcodes from our other processes

## How to test
