### PR TITLE
GRIN initial scrape script update

### DIFF
--- a/etl-pipeline/scripts/GRIN_initial_scrape.py
+++ b/etl-pipeline/scripts/GRIN_initial_scrape.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from services.grin.grin_client import GRINClient
 from services.grin.util import chunk
 
-DEFAULT_CHUNK_SIZE = 1000
+DEFAULT_CHUNK_SIZE = 5000
 
 logging.basicConfig(
     filename="GRIN_initial_scrape.log",

--- a/etl-pipeline/scripts/GRIN_initial_scrape.py
+++ b/etl-pipeline/scripts/GRIN_initial_scrape.py
@@ -81,6 +81,7 @@ if __name__ == "__main__":
         parser.add_argument("--batch_limit")
         args = parser.parse_args()
         batch_limit = args.batch_limit
+
         main(batch_limit)
     except Exception as e:
         logging.exception(e, exc_info=True)

--- a/etl-pipeline/scripts/GRIN_initial_scrape.py
+++ b/etl-pipeline/scripts/GRIN_initial_scrape.py
@@ -3,7 +3,6 @@ import logging
 from typing import List, Iterator
 from model import GRINState, GRINStatus, Record, FRBRStatus
 from managers import DBManager
-from sqlalchemy.dialects.postgresql import insert
 from uuid import uuid4
 from services.grin.grin_client import GRINClient
 from services.grin.util import chunk

--- a/etl-pipeline/scripts/GRIN_initial_scrape.py
+++ b/etl-pipeline/scripts/GRIN_initial_scrape.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
         parser = argparse.ArgumentParser()
         parser.add_argument("--batch_limit")
         args = parser.parse_args()
-        batch_limit = args.batch_limit
+        batch_limit = int(args.batch_limit)
 
         main(batch_limit)
     except Exception as e:

--- a/etl-pipeline/scripts/GRIN_initial_scrape.py
+++ b/etl-pipeline/scripts/GRIN_initial_scrape.py
@@ -1,20 +1,14 @@
 from datetime import datetime
 import logging
 from typing import List, Iterator
-from google.auth.transport.requests import (
-    AuthorizedSession,
-)
 from model import GRINState, GRINStatus, Record, FRBRStatus
 from managers import DBManager
-from google.oauth2.service_account import Credentials
-import json
-from services.ssm_service import SSMService
+from sqlalchemy.dialects.postgresql import insert
 from uuid import uuid4
-import os
+from services.grin.grin_client import GRINClient
+from services.grin.util import chunk
 
-
-DEFAULT_BASE_URL = "https://books.google.com/libraries/NYPL"
-DEFAULT_CHUNK_SIZE = 5000
+DEFAULT_CHUNK_SIZE = 1000
 
 logging.basicConfig(
     filename="GRIN_initial_scrape.log",
@@ -22,55 +16,28 @@ logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s",
 )
 
-
-class AuthSession(object):
-    """Eventually, this will a service, we will use this mock code for now"""
-
-    def __init__(self):
-        self.creds = self.load_creds()
-        self.session = AuthorizedSession(self.creds)
-
-    def get_session(self):
-        return self.session
-
-    def load_creds(self):
-        ssm_service = SSMService()
-        service_account_file = ssm_service.get_parameter("grin-auth")
-        service_account_info = json.loads(service_account_file)
-
-        scopes = [
-            "openid",
-            "https://www.googleapis.com/auth/userinfo.email",
-            "https://www.googleapis.com/auth/userinfo.profile",
-        ]
-
-        creds = Credentials.from_service_account_info(
-            service_account_info, scopes=scopes
-        )
-        return creds
-
-
 def main():
-    auth = AuthSession()
-    authed_session = auth.get_session()
+    grin_client = GRINClient()
+    with DBManager(
+            user="localuser",
+            pswd="localpsql",
+            host="localhost",
+            port="5432",
+            db="drb_test_db",
+        ) as db_manager:
+        url = grin_client._url(f"_all_books?book_state=NEW&book_state=PREVIOUSLY_DOWNLOADED&format=text")
+        print(f"Scraping url: {url}")
 
-    db_manager = DBManager()
-    db_manager.create_session()
+        response = grin_client.session.request("GET", url, timeout=600)
+        response.raise_for_status()
 
-    url = f"{DEFAULT_BASE_URL}/_all_books?book_state=NEW&book_state=PREVIOUSLY_DOWNLOADED&format=text"
-    logging.info(f"Scraping url: {url}")
-
-    response = authed_session.get(url, timeout=600)
-    response.raise_for_status()
-
-    barcodes = response.content.decode("utf8").strip().split("\n")
-
-    if len(barcodes) > 0:
-        insert_into_db(
-            barcodes=barcodes, db_manager=db_manager, chunk_size=DEFAULT_CHUNK_SIZE
-        )
-    else:
-        logging.info("No record found")
+        barcodes = response.content.decode("utf8").strip().split("\n")
+        if len(barcodes) > 0:
+            insert_into_db(
+                barcodes=barcodes, db_manager=db_manager, chunk_size=DEFAULT_CHUNK_SIZE
+            )
+        else:
+            logging.info("No record found")
 
 
 def insert_into_db(barcodes: List[str], db_manager: DBManager, chunk_size: int):
@@ -79,46 +46,38 @@ def insert_into_db(barcodes: List[str], db_manager: DBManager, chunk_size: int):
     for chunked_barcodes in chunk(iter(barcodes), chunk_size):
         new_records: List[Record] = []
         for barcode in chunked_barcodes:
-            new_records.append(
-                Record(
-                    uuid=uuid4(),
-                    frbr_status=FRBRStatus.TODO.value,
-                    source_id=f"{barcode}|grin",
-                    grin_status=GRINStatus(
-                        barcode=barcode,
-                        failed_download=0,
-                        state=GRINState.PENDING_CONVERSION.value,
-                        date_created=datetime(1991, 8, 25),
-                    ),
-                )
+            existing_record = (
+            db_manager.session.query(Record)
+            .filter(Record.source_id == f"{barcode}|grin")
+            .first()
             )
-
-        logging.info(f"Inserting {len(chunked_barcodes)} barcodes into Record")
+            if not existing_record:
+                new_records.append(
+                    Record(
+                        uuid=uuid4(),
+                        frbr_status=FRBRStatus.TODO.value,
+                        source_id=f"{barcode}|grin",
+                        source="grin",
+                        grin_status=GRINStatus(
+                            barcode=barcode,
+                            failed_download=0,
+                            state=GRINState.PENDING_CONVERSION.value,
+                            date_created=datetime(1991, 8, 25),
+                        ),
+                    )
+            )
+        logging.info(f"Inserting {len(new_records)} barcodes into Record")
 
         try:
             db_manager.session.add_all(new_records)
             db_manager.commit_changes()
         except Exception:
-            logging.exception("Failed to insert barcodes")
-            logging.exception(chunked_barcodes)
+            logging.exception(f"Failed to insert barcodes: {chunked_barcodes}")
             raise
-
+        
+        break
     logging.info("Complete.")
-
-
-def chunk(xs: Iterator, size: int) -> Iterator[list]:
-    while True:
-        chunk = []
-        try:
-            for _ in range(size):
-                chunk.append(next(xs))
-            yield chunk
-        except StopIteration:
-            if chunk:
-                yield chunk
-
-            break
-
+    
 
 if __name__ == "__main__":
     try:

--- a/etl-pipeline/scripts/GRIN_initial_scrape.py
+++ b/etl-pipeline/scripts/GRIN_initial_scrape.py
@@ -16,16 +16,13 @@ logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s",
 )
 
+
 def main():
     grin_client = GRINClient()
-    with DBManager(
-            user="localuser",
-            pswd="localpsql",
-            host="localhost",
-            port="5432",
-            db="drb_test_db",
-        ) as db_manager:
-        url = grin_client._url(f"_all_books?book_state=NEW&book_state=PREVIOUSLY_DOWNLOADED&format=text")
+    with DBManager() as db_manager:
+        url = grin_client._url(
+            f"_all_books?book_state=NEW&book_state=PREVIOUSLY_DOWNLOADED&format=text"
+        )
         print(f"Scraping url: {url}")
 
         response = grin_client.session.request("GET", url, timeout=600)
@@ -47,9 +44,9 @@ def insert_into_db(barcodes: List[str], db_manager: DBManager, chunk_size: int):
         new_records: List[Record] = []
         for barcode in chunked_barcodes:
             existing_record = (
-            db_manager.session.query(Record)
-            .filter(Record.source_id == f"{barcode}|grin")
-            .first()
+                db_manager.session.query(Record)
+                .filter(Record.source_id == f"{barcode}|grin")
+                .first()
             )
             if not existing_record:
                 new_records.append(
@@ -65,7 +62,7 @@ def insert_into_db(barcodes: List[str], db_manager: DBManager, chunk_size: int):
                             date_created=datetime(1991, 8, 25),
                         ),
                     )
-            )
+                )
         logging.info(f"Inserting {len(new_records)} barcodes into Record")
 
         try:
@@ -74,10 +71,10 @@ def insert_into_db(barcodes: List[str], db_manager: DBManager, chunk_size: int):
         except Exception:
             logging.exception(f"Failed to insert barcodes: {chunked_barcodes}")
             raise
-        
+
         break
     logging.info("Complete.")
-    
+
 
 if __name__ == "__main__":
     try:

--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -143,4 +143,4 @@ if __name__ == "__main__":
     batch_limit = args.batch_limit
 
     grin_conversion = GRINConversion(batch_limit)
-    # grin_conversion.run_process(backfill=True)
+    grin_conversion.run_process(backfill=True)

--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -86,6 +86,7 @@ class GRINConversion:
                         uuid=uuid4(),
                         frbr_status=FRBRStatus.TODO.value,
                         source_id=f"{barcode}|grin",
+                        source="grin",
                         grin_status=GRINStatus(
                             barcode=barcode, failed_download=0, state=state.value
                         ),

--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -11,14 +11,14 @@ from managers import DBManager
 from uuid import uuid4
 from logger import create_log
 from .util import chunk
-
-CHUNK_SIZE = 1000
+import argparse
 
 
 class GRINConversion:
-    def __init__(self):
+    def __init__(self, batch_limit=1000):
         self.client = GRINClient()
         self.logger = create_log(__name__)
+        self.batch_limit = batch_limit
 
     def run_process(self, backfill=False):
         with DBManager() as self.db_manager:
@@ -27,7 +27,7 @@ class GRINConversion:
             self.process_converted_books()
 
             if backfill:
-                self.convert_backfills(CHUNK_SIZE)
+                self.convert_backfills()
 
     def acquire_and_convert_new_books(self):
         data = self.client.acquired_today()
@@ -39,14 +39,14 @@ class GRINConversion:
 
             self.save_barcodes(converting_barcodes, GRINState.CONVERTING)
 
-    def convert_backfills(self, batch_size):
+    def convert_backfills(self):
         backfill_query = (
             select(GRINStatus.barcode)
             .where(
                 GRINStatus.state == GRINState.PENDING_CONVERSION.value,
             )
             .where(GRINStatus.date_created <= GRINStatus.backfill_timestamp())
-            .limit(batch_size)
+            .limit(self.batch_limit)
         )
 
         backfilled_barcodes = (
@@ -78,7 +78,7 @@ class GRINConversion:
         if barcodes.empty:
             return
 
-        for chunked_barcodes in chunk(iter(barcodes), CHUNK_SIZE):
+        for chunked_barcodes in chunk(iter(barcodes), self.batch_limit):
             records: List[Record] = []
             for barcode in chunked_barcodes:
                 records.append(
@@ -106,7 +106,7 @@ class GRINConversion:
         if not converted_barcodes:
             return
 
-        for chunked_barcodes in chunk(iter(converted_barcodes), CHUNK_SIZE):
+        for chunked_barcodes in chunk(iter(converted_barcodes), self.batch_limit):
             stripped_barcodes: List[str] = []
             for barcode in chunked_barcodes:
                 # converted file name has the following pattern 1234.tar.gz.gpg
@@ -137,5 +137,10 @@ class GRINConversion:
 
 
 if __name__ == "__main__":
-    grin_conversion = GRINConversion()
-    grin_conversion.run_process(backfill=True)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch_limit")
+    args = parser.parse_args()
+    batch_limit = args.batch_limit
+
+    grin_conversion = GRINConversion(batch_limit)
+    # grin_conversion.run_process(backfill=True)

--- a/etl-pipeline/services/grin/conversion.py
+++ b/etl-pipeline/services/grin/conversion.py
@@ -140,7 +140,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--batch_limit")
     args = parser.parse_args()
-    batch_limit = args.batch_limit
+    batch_limit = int(args.batch_limit)
 
     grin_conversion = GRINConversion(batch_limit)
     grin_conversion.run_process(backfill=True)

--- a/etl-pipeline/services/grin/download.py
+++ b/etl-pipeline/services/grin/download.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--batch_limit")
     args = parser.parse_args()
-    batch_limit = args.batch_limit
+    batch_limit = int(args.batch_limit)
 
     grin_download = GRINDownload(batch_limit)
     grin_download.run_process(backfill=True)

--- a/etl-pipeline/services/grin/download.py
+++ b/etl-pipeline/services/grin/download.py
@@ -23,7 +23,6 @@ class GRINDownload:
             else "drb-files-limited-qa"
         )
         self.batch_limit = batch_limit
-        print(self.batch_limit)
 
     def run_process(self, backfill=False):
         with DBManager() as self.db_manager:

--- a/etl-pipeline/services/grin/download.py
+++ b/etl-pipeline/services/grin/download.py
@@ -108,4 +108,4 @@ if __name__ == "__main__":
     batch_limit = args.batch_limit
 
     grin_download = GRINDownload(batch_limit)
-    # grin_download.run_process(backfill=True)
+    grin_download.run_process(backfill=True)


### PR DESCRIPTION
## Describe your changes
The GRIN initial scrape script grabs all of the barcodes that exist in GRIN and inserts them into the DB. Upon testing locally, I found that the script failed when a record with the same barcode already exists in the DB - instead, we want it to just skip over that barcode and continue inserting. This PR adds logic for that as well as cleans up the scrape script to use the GrinClient and makes the batch size an argument, so that we can configure this more easily. Because we'd like to insert a smaller subset of books in QA and Prod, I added a break in the loop to finish after one batch of books (will remove this when we want to run the script in its entirety).

Lastly, I made the batch size configurable as a command line argument in the conversion and download script as well. 

## How to test
Run `python3 -m scripts.GRIN_initial_scrape --batch_limit=5` which should insert 5 books from GRIN's site into your DB locally (in the Records table and in the GRINStatus table). If you run it again, the script should succeed but just not insert anything into your DB.