### PR TITLE
[DO NOT MERGE][SCHOL-7] Link out embed links

### DIFF
--- a/web/src/__tests__/Search.test.tsx
+++ b/web/src/__tests__/Search.test.tsx
@@ -381,7 +381,7 @@ describe("Renders Search Results Page", () => {
       test("Shows 'read online' as link", () => {
         expect(
           screen.getAllByText("Read Online")[0].closest("a").href
-        ).toContain("read/3330416");
+        ).toContain("https://test-link-url-2/");
       });
       test("Number of editions links to work page", () => {
         expect(
@@ -499,7 +499,7 @@ describe("Renders Search Results Page", () => {
       test("Shows 'read online' as link", () => {
         expect(
           screen.getAllByText("Read Online")[1].closest("a").href
-        ).toContain("read/3234");
+        ).toContain("https://test-link-url-5/");
       });
       test("Number of editions links to work page", () => {
         expect(

--- a/web/src/components/EditionCard/ReadOnlineLink.tsx
+++ b/web/src/components/EditionCard/ReadOnlineLink.tsx
@@ -6,6 +6,8 @@ import { ItemLink } from "~/src/types/DataModel";
 import { LOGIN_TO_READ_TEST_ID } from "~/src/constants/testIds";
 import { getHostname } from "~/src/util/LinkUtils";
 import { trackEvent } from "~/src/lib/gtag/Analytics";
+import { formatUrl } from "~/src/util/Util";
+
 
 // "Read Online" button should only show up if the link was flagged as "reader" or "embed"
 const ReadOnlineLink: React.FC<{
@@ -16,7 +18,7 @@ const ReadOnlineLink: React.FC<{
   loginCookie?: any;
 }> = ({  authors, isLoggedIn, readOnlineLink, title }) => {
   let linkText = "Read Online";
-  let linkUrl: any = {
+  let linkUrl: any = readOnlineLink.flags.embed ? formatUrl(readOnlineLink.url) : {
     pathname: `/read/${readOnlineLink.link_id}`,
   };
 
@@ -46,7 +48,7 @@ const ReadOnlineLink: React.FC<{
       <Box data-testid={LOGIN_TO_READ_TEST_ID}>
         <Link
           to={linkUrl}
-          linkType="button"
+          linkType={readOnlineLink.flags.embed ? "external" : "button"}
           aria-label={`${title} ${linkText}`}
           onClick={trackReadOnlineClick}
         >


### PR DESCRIPTION
## Describe your changes
- This change links out for embed links instead of embedding them

## How to test
- Navigate to `/search?query=keyword%3ADas+gantz+Neuw+Testament`
- Click on read online


All good that the tests are failing. This change was to show design/product what the potential flow would look like for our patrons. 
