### PR TITLE
Kick off file conversion after GRIN download

### DIFF
--- a/etl-pipeline/managers/nypl_api.py
+++ b/etl-pipeline/managers/nypl_api.py
@@ -32,10 +32,10 @@ class NYPLAPIManager:
         self.generate_access_token()
         self.create_client()
 
-        response = self.client.post(self.api_root + "/pdf-pipeline/workflow", data=json.dumps({
-            "bucket": bucket,
-            "mets_key": mets_key
-        }))
+        response = self.client.post(
+            self.api_root + "/pdf-pipeline/workflow",
+            data=json.dumps({"bucket": bucket, "mets_key": mets_key}),
+        )
 
         return response.json()
 

--- a/etl-pipeline/managers/nypl_api.py
+++ b/etl-pipeline/managers/nypl_api.py
@@ -37,7 +37,7 @@ class NYPLAPIManager:
             data=json.dumps({"bucket": bucket, "mets_key": mets_key}),
         )
 
-        return response.json()
+        return response
 
     def query_api(self, request_path):
         if not self.client:

--- a/etl-pipeline/managers/nypl_api.py
+++ b/etl-pipeline/managers/nypl_api.py
@@ -1,5 +1,6 @@
 from oauthlib.oauth2 import BackendApplicationClient, TokenExpiredError
 import os
+import json
 from requests_oauthlib import OAuth2Session
 
 
@@ -26,6 +27,17 @@ class NYPLAPIManager:
 
     def create_client(self):
         self.client = OAuth2Session(self.client_id, token=self.token)
+
+    def post_file_conversion_workflow(self, bucket, mets_key):
+        self.generate_access_token()
+        self.create_client()
+
+        response = self.client.post(self.api_root + "/pdf-pipeline/workflow", data=json.dumps({
+            "bucket": bucket,
+            "mets_key": mets_key
+        }))
+
+        return response.json()
 
     def query_api(self, request_path):
         if not self.client:

--- a/etl-pipeline/processes/grin/conversion.py
+++ b/etl-pipeline/processes/grin/conversion.py
@@ -21,7 +21,13 @@ class GRINConversion:
         self.batch_limit = batch_limit
 
     def runProcess(self, backfill=True):
-        with DBManager() as self.db_manager:
+        with DBManager(
+            user="localuser",
+            pswd="localpsql",
+            host="localhost",
+            port="5432",
+            db="drb_test_db",
+        ) as self.db_manager:
             self.acquire_and_convert_new_books()
 
             self.process_converted_books()
@@ -30,12 +36,12 @@ class GRINConversion:
                 self.convert_backfills()
 
     def acquire_and_convert_new_books(self):
-        data = self.client.acquired_today()
+        data = self.client.acquired_today()[:12]
         if len(data) > 2:
             new_books_df = self.transform_scraped_data(data)
             new_barcodes = new_books_df.query('State == "NEW"')
 
-            converting_barcodes = self.convert_barcodes(new_barcodes["Barcode"])
+            converting_barcodes, converted_barcodes = self.convert_barcodes(new_barcodes["Barcode"])
 
             self.logger.info(f"Acquired and converted {len(converting_barcodes)} books")
 
@@ -108,7 +114,7 @@ class GRINConversion:
         return converting_barcodes["Barcode"], converted_barcodes["Barcode"]
 
     def save_barcodes(self, barcodes, state):
-        if barcodes.empty:
+        if len(barcodes) == 0:
             return
 
         for chunked_barcodes in chunk(iter(barcodes), self.batch_limit):
@@ -159,6 +165,15 @@ class GRINConversion:
 
                 self.logger.info(
                     f"Updated {updated_results.rowcount} converted books in DB"
+                )
+
+                barcodes_in_table = [grin_status.barcode for grin_status in self.db_manager.session.query(GRINStatus.barcode).all()]
+                missing_from_table = [barcode for barcode in stripped_barcodes if barcode not in barcodes_in_table]
+
+                self.save_barcodes(missing_from_table, GRINState.CONVERTED)
+                
+                self.logger.info(
+                    f"Saved {len(missing_from_table)} new converted books in DB"
                 )
             except:
                 self.db_manager.session.rollback()

--- a/etl-pipeline/processes/grin/conversion.py
+++ b/etl-pipeline/processes/grin/conversion.py
@@ -21,13 +21,7 @@ class GRINConversion:
         self.batch_limit = batch_limit
 
     def runProcess(self, backfill=True):
-        with DBManager(
-            user="localuser",
-            pswd="localpsql",
-            host="localhost",
-            port="5432",
-            db="drb_test_db",
-        ) as self.db_manager:
+        with DBManager() as self.db_manager:
             self.acquire_and_convert_new_books()
 
             self.process_converted_books()
@@ -36,7 +30,7 @@ class GRINConversion:
                 self.convert_backfills()
 
     def acquire_and_convert_new_books(self):
-        data = self.client.acquired_today()[:12]
+        data = self.client.acquired_today()
         if len(data) > 2:
             new_books_df = self.transform_scraped_data(data)
             new_barcodes = new_books_df.query('State == "NEW"')

--- a/etl-pipeline/processes/grin/conversion.py
+++ b/etl-pipeline/processes/grin/conversion.py
@@ -35,7 +35,9 @@ class GRINConversion:
             new_books_df = self.transform_scraped_data(data)
             new_barcodes = new_books_df.query('State == "NEW"')
 
-            converting_barcodes, converted_barcodes = self.convert_barcodes(new_barcodes["Barcode"])
+            converting_barcodes, converted_barcodes = self.convert_barcodes(
+                new_barcodes["Barcode"]
+            )
 
             self.logger.info(f"Acquired and converted {len(converting_barcodes)} books")
 
@@ -161,11 +163,20 @@ class GRINConversion:
                     f"Updated {updated_results.rowcount} converted books in DB"
                 )
 
-                barcodes_in_table = [grin_status.barcode for grin_status in self.db_manager.session.query(GRINStatus.barcode).all()]
-                missing_from_table = [barcode for barcode in stripped_barcodes if barcode not in barcodes_in_table]
+                barcodes_in_table = [
+                    grin_status.barcode
+                    for grin_status in self.db_manager.session.query(
+                        GRINStatus.barcode
+                    ).all()
+                ]
+                missing_from_table = [
+                    barcode
+                    for barcode in stripped_barcodes
+                    if barcode not in barcodes_in_table
+                ]
 
                 self.save_barcodes(missing_from_table, GRINState.CONVERTED)
-                
+
                 self.logger.info(
                     f"Saved {len(missing_from_table)} new converted books in DB"
                 )

--- a/etl-pipeline/processes/grin/download.py
+++ b/etl-pipeline/processes/grin/download.py
@@ -1,5 +1,5 @@
 from .grin_client import GRINClient
-from managers import DBManager, S3Manager
+from managers import DBManager, S3Manager, NYPLAPIManager
 from model import GRINStatus, GRINState
 from services.ssm_service import SSMService
 import gnupg
@@ -22,12 +22,21 @@ class GRINDownload:
             else "drb-files-limited-qa"
         )
         self.barcode = str(barcode)
+        
+        self.nypl_api_manager = NYPLAPIManager()   
 
     def run_process(self):
         with DBManager() as self.db_manager:
             file_content = self.download_and_upload_book()
 
             self.unpack_and_upload_ocr_files(file_content)
+
+            mets_key = f"grin/{self.barcode}/NYPL_{self.barcode}.xml"
+            response = self.nypl_api_manager.post_file_conversion_workflow(self.bucket, mets_key)
+            if response == "200":
+                self.logger.info("Successfully started file conversion")
+            else:
+                self.logger.info("File conversion failed to start. Error:" + response.content)
 
     def download_and_upload_book(self):
         grin_status = self.db_manager.session.get(GRINStatus, self.barcode)

--- a/etl-pipeline/processes/grin/download.py
+++ b/etl-pipeline/processes/grin/download.py
@@ -22,8 +22,8 @@ class GRINDownload:
             else "drb-files-limited-qa"
         )
         self.barcode = str(barcode)
-        
-        self.nypl_api_manager = NYPLAPIManager()   
+
+        self.nypl_api_manager = NYPLAPIManager()
 
     def run_process(self):
         with DBManager() as self.db_manager:
@@ -32,11 +32,15 @@ class GRINDownload:
             self.unpack_and_upload_ocr_files(file_content)
 
             mets_key = f"grin/{self.barcode}/NYPL_{self.barcode}.xml"
-            response = self.nypl_api_manager.post_file_conversion_workflow(self.bucket, mets_key)
+            response = self.nypl_api_manager.post_file_conversion_workflow(
+                self.bucket, mets_key
+            )
             if response == "200":
                 self.logger.info("Successfully started file conversion")
             else:
-                self.logger.info("File conversion failed to start. Error:" + response.content)
+                self.logger.info(
+                    "File conversion failed to start. Error:" + response.content
+                )
 
     def download_and_upload_book(self):
         grin_status = self.db_manager.session.get(GRINStatus, self.barcode)

--- a/etl-pipeline/processes/grin/download.py
+++ b/etl-pipeline/processes/grin/download.py
@@ -3,7 +3,7 @@ from managers import DBManager, S3Manager, NYPLAPIManager
 from model import GRINStatus, GRINState
 from services.ssm_service import SSMService
 import gnupg
-import logging
+from logger import create_log
 import os
 import io
 import argparse
@@ -13,7 +13,7 @@ import tarfile
 class GRINDownload:
     def __init__(self, barcode):
         self.grin_client = GRINClient()
-        self.logger = logging.getLogger()
+        self.logger = create_log(__name__)
         self.s3_manager = S3Manager()
         self.ssm_service = SSMService()
         self.bucket = (
@@ -39,7 +39,7 @@ class GRINDownload:
                 self.logger.info("Successfully started file conversion")
             else:
                 self.logger.info(
-                    "File conversion failed to start. Error:" + response.content
+                    f"File conversion failed to start. Error: {response.json()}"
                 )
 
     def download_and_upload_book(self):

--- a/etl-pipeline/processes/grin/download.py
+++ b/etl-pipeline/processes/grin/download.py
@@ -35,7 +35,7 @@ class GRINDownload:
             response = self.nypl_api_manager.post_file_conversion_workflow(
                 self.bucket, mets_key
             )
-            if response == "200":
+            if response.status_code == 200:
                 self.logger.info("Successfully started file conversion")
             else:
                 self.logger.info(


### PR DESCRIPTION
## Describe your changes
This PR kicks off the file conversion step function after a book is downloaded and extracted from GRIN. It also adds the file conversion kick off to the NYPL API Manager to keep the API code together.

This PR also takes care of a small GRIN conversion edge case where books that were updated as converted but not yet in our DB would be passed over.

## How to test
`python3 -m processes.grin.download --barcode=33433115534533` (This is a new barcode extracted and uploaded to our QA bucket)
