### PR TITLE
Fix util reference in GRIN scrape

### DIFF
--- a/etl-pipeline/scripts/GRIN_initial_scrape.py
+++ b/etl-pipeline/scripts/GRIN_initial_scrape.py
@@ -5,7 +5,7 @@ from model import GRINState, GRINStatus, Record, FRBRStatus
 from managers import DBManager
 from uuid import uuid4
 from processes.grin.grin_client import GRINClient
-from processes.grin.util import chunk
+from processes.util.chunk import chunk
 import argparse
 
 logger = create_log(__name__)

--- a/etl-pipeline/scripts/updateOldInTechOpenLinks.py
+++ b/etl-pipeline/scripts/updateOldInTechOpenLinks.py
@@ -3,7 +3,8 @@ import re
 
 from model import Record
 from managers import DBManager
-from processes import DOABProcess
+from processes import IngestProcess
+from model import Source
 
 
 def main():
@@ -19,7 +20,7 @@ def main():
 
     dbManager.create_session()
 
-    doabProcess = DOABProcess("single", None, None, None, None, None)
+    doabProcess = IngestProcess("single", None, None, None, None, None, Source.DOAB.value)
 
     identRegex = r"intechopen.com\/books\/([\d]+)"
 


### PR DESCRIPTION
## Describe your changes
This PR updates the way we are referencing the `util` chunk in the GRIN scrape script which is causing the script to fail right now. There is also an issue with an old script -updateOldInTechOpenLinks.py that is trying to reference `DoabProcess` that no longer exists. I changed that script to make use of the new IngestProcess.

## How to test
Ensure you can run the `GRIN_initial_scrape.py`