### PR TITLE
Remove slack playwright notification

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -63,13 +63,3 @@ jobs:
         env:
           CATALOG_USERNAME: ${{ secrets.CATALOG_USERNAME }}
           CATALOG_USER_PIN: ${{ secrets.CATALOG_USER_PIN }}
-
-      - name: Slack Notification
-        if: ${{ always() }}
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: test_reports
-          SLACK_MESSAGE: See test results in ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          SLACK_TITLE: DRB Web Playwright Test Results
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_USERNAME: nyplorgBot


### PR DESCRIPTION
## Describe your changes
- Since these tests run on every PR and after QA deployments, the Slack notification to the `#test-reports` channel is not useful. Instead, failures are reported on PRs and emails sent to the engineer who pushed the code.

## How to test
