### PR TITLE
[SCHOL-66] Reduce memory usage in GRIN download

### DIFF
--- a/etl-pipeline/processes/grin/download.py
+++ b/etl-pipeline/processes/grin/download.py
@@ -1,11 +1,15 @@
+import io
+import os
+import tarfile
+import tempfile
+import gnupg
+import shutil
+
 from .grin_client import GRINClient
 from managers import DBManager, S3Manager
 from model import GRINStatus, GRINState
 from services.ssm_service import SSMService
-import gnupg
 from logger import create_log
-import io
-import tarfile
 
 logger = create_log(__name__)
 
@@ -21,66 +25,87 @@ class GRINDownloadService:
         barcode = str(barcode)
         ocr_dir = f"grin/{barcode}/"
 
-        with DBManager() as self.db_manager:
-            file_content = self.download_and_upload_book(barcode, ocr_dir)
+        with DBManager() as self.db_manager, tempfile.TemporaryDirectory() as tmp_dir:
+            grin_status = self.db_manager.session.get(GRINStatus, barcode)
 
-            self.unpack_and_upload_ocr_files(ocr_dir, barcode, file_content)
+            tmp_ocr_package = self.download_ocr_package(barcode, grin_status, tmp_dir)
+            self.upload_ocr_package(barcode, ocr_dir, tmp_ocr_package, grin_status)
+            self.upload_unpacked_ocr_files(barcode, ocr_dir, tmp_ocr_package, tmp_dir)
 
             mets_file = ocr_dir + f"NYPL_{barcode}.xml"
-
             return ocr_dir, mets_file
 
-    def download_and_upload_book(self, barcode, ocr_dir):
-        grin_status = self.db_manager.session.get(GRINStatus, barcode)
-        file_name = f"{barcode}.tar.gz.gpg"
-        s3_key = ocr_dir + file_name
+    def download_ocr_package(self, barcode, grin_status: GRINStatus, tmp_dir):
+        ocr_package_name = f"{barcode}.tar.gz.gpg"
+        tmp_ocr_package = os.path.join(tmp_dir, ocr_package_name)
 
         try:
-            content = self.grin_client.download(file_name)
-            logger.info(f"Downloading {barcode} from GRIN")
-        except:
-            logger.exception(f"Error downloading content for {barcode}")
+            response = self.grin_client.download(ocr_package_name, stream=True)
+            logger.info(f"Downloading {barcode} OCR package from GRIN")
+
+            
+            with response:
+                response.raise_for_status()
+                
+                with open(tmp_ocr_package, "wb") as ocr_package:
+                    shutil.copyfileobj(response.raw, ocr_package)
+
+            return tmp_ocr_package
+        except Exception:
+            logger.exception(f"Error downloading OCR package for {barcode}")
             grin_status.failed_download += 1
             self.db_manager.commit_changes()
-            return
+            raise Exception(f"Failed to download OCR package for {barcode}")
+
+    def upload_ocr_package(self, barcode, ocr_dir, tmp_file, grin_status: GRINStatus):
+        ocr_package_key = ocr_dir + f"{barcode}.tar.gz.gpg"
 
         try:
-            self.s3_manager.put_object(
-                object=content,
-                key=s3_key,
-                bucket=self.bucket,
-                bucket_permissions=None,
-                storage_class="GLACIER_IR",
-            )
-            logger.info(f"Uploading {barcode} TAR to s3")
-        except Exception as e:
-            logger.exception(f"Error uploading to s3 for {barcode}")
-            return
+            with open(tmp_file, "rb") as ocr_package:
+                self.s3_manager.client.upload_fileobj(
+                    Fileobj=ocr_package,
+                    Bucket=self.bucket,
+                    Key=ocr_package_key,
+                    ExtraArgs={"StorageClass": "GLACIER_IR"},
+                )
+            logger.info(f"Uploading {barcode} OCR package to s3")
+        except Exception:
+            logger.exception(f"Error uploading OCR package to s3 for {barcode}")
+            raise Exception(f"Failed to upload OCR package for {barcode}")
 
         grin_status.state = GRINState.DOWNLOADED.value
         self.db_manager.commit_changes()
 
-        return content
+        return ocr_package_key
 
-    def unpack_and_upload_ocr_files(self, ocr_dir, barcode, file_content):
+    def upload_unpacked_ocr_files(self, barcode, ocr_dir, tmp_ocr_package, tmp_dir):
+        decrypted_ocr_package = os.path.join(tmp_dir, f"{barcode}.tar.gz")
+
+        logger.info(f"Decrypting {barcode} OCR package")
         gpg = gnupg.GPG()
-        decrypted_content = gpg.decrypt(
-            file_content,
-            always_trust=True,
-            passphrase=self.ssm_service.get_parameter("grin-access-key"),
-        )
+        with open(tmp_ocr_package, "rb") as encrypted_file:
+            decrypt_result = gpg.decrypt_file(
+                encrypted_file,
+                passphrase=self.ssm_service.get_parameter("grin-access-key"),
+                output=decrypted_ocr_package,
+            )
 
-        tar_stream_data = io.BytesIO(decrypted_content.data)
+        if not decrypt_result.ok:
+            logger.error(f"GPG decryption failed for {barcode}: {decrypt_result.status}")
+            raise Exception(f"Failed to decrypt OCR package for {barcode}")
 
         logger.info(f"Unpacking and uploading {barcode} OCR files to s3")
         try:
-            with tarfile.open(fileobj=tar_stream_data, mode="r|*") as tar_file:
+            with tarfile.open(decrypted_ocr_package, mode="r|*") as tar_file:
                 for file in tar_file:
-                    self.s3_manager.put_object(
-                        object=tar_file.extractfile(file).read(),
-                        key=ocr_dir + str(file.name),
-                        bucket=self.bucket,
-                        bucket_permissions=None,
-                    )
-        except tarfile.StreamError as e:
-            print(f"Error reading stream: {e}")
+                    file_obj = tar_file.extractfile(file)
+                    
+                    if file_obj:
+                        self.s3_manager.client.upload_fileobj(
+                            io.BytesIO(file_obj.read()),
+                            Bucket=self.bucket,
+                            Key=ocr_dir + file.name,
+                        )
+        except tarfile.TarError:
+            logger.exception(f"Error unpacking OCR package for {barcode}")
+            raise Exception(f"Failed to unpack OCR package for {barcode}")

--- a/etl-pipeline/processes/grin/download.py
+++ b/etl-pipeline/processes/grin/download.py
@@ -56,7 +56,9 @@ class GRINDownloadService:
             self.db_manager.commit_changes()
             raise Exception(f"Failed to download OCR package for {barcode}")
 
-    def upload_ocr_package(self, barcode, ocr_dir, tmp_ocr_package, grin_status: GRINStatus):
+    def upload_ocr_package(
+        self, barcode, ocr_dir, tmp_ocr_package, grin_status: GRINStatus
+    ):
         ocr_package_key = ocr_dir + f"{barcode}.tar.gz.gpg"
 
         try:

--- a/etl-pipeline/processes/grin/download.py
+++ b/etl-pipeline/processes/grin/download.py
@@ -56,11 +56,11 @@ class GRINDownloadService:
             self.db_manager.commit_changes()
             raise Exception(f"Failed to download OCR package for {barcode}")
 
-    def upload_ocr_package(self, barcode, ocr_dir, tmp_file, grin_status: GRINStatus):
+    def upload_ocr_package(self, barcode, ocr_dir, tmp_ocr_package, grin_status: GRINStatus):
         ocr_package_key = ocr_dir + f"{barcode}.tar.gz.gpg"
 
         try:
-            with open(tmp_file, "rb") as ocr_package:
+            with open(tmp_ocr_package, "rb") as ocr_package:
                 self.s3_manager.client.upload_fileobj(
                     Fileobj=ocr_package,
                     Bucket=self.bucket,

--- a/etl-pipeline/processes/grin/download.py
+++ b/etl-pipeline/processes/grin/download.py
@@ -43,10 +43,9 @@ class GRINDownloadService:
             response = self.grin_client.download(ocr_package_name, stream=True)
             logger.info(f"Downloading {barcode} OCR package from GRIN")
 
-            
             with response:
                 response.raise_for_status()
-                
+
                 with open(tmp_ocr_package, "wb") as ocr_package:
                     shutil.copyfileobj(response.raw, ocr_package)
 
@@ -91,7 +90,9 @@ class GRINDownloadService:
             )
 
         if not decrypt_result.ok:
-            logger.error(f"GPG decryption failed for {barcode}: {decrypt_result.status}")
+            logger.error(
+                f"GPG decryption failed for {barcode}: {decrypt_result.status}"
+            )
             raise Exception(f"Failed to decrypt OCR package for {barcode}")
 
         logger.info(f"Unpacking and uploading {barcode} OCR files to s3")
@@ -99,7 +100,7 @@ class GRINDownloadService:
             with tarfile.open(decrypted_ocr_package, mode="r|*") as tar_file:
                 for file in tar_file:
                     file_obj = tar_file.extractfile(file)
-                    
+
                     if file_obj:
                         self.s3_manager.client.upload_fileobj(
                             io.BytesIO(file_obj.read()),

--- a/etl-pipeline/processes/grin/grin_client.py
+++ b/etl-pipeline/processes/grin/grin_client.py
@@ -33,12 +33,15 @@ class GRINClient(object):
     def _url(self, fragment):
         return "https://books.google.com/libraries/NYPL/" + fragment
 
-    def get(self, fragment):
+    def get(self, fragment, stream=False, **kwargs):
         url = self._url(fragment)
-        response = self.session.request("GET", url)
+        
+        response = self.session.request("GET", url, stream=stream, **kwargs)
+        
         if response.status_code != 200:
             raise IOError("%s got %s unexpectedly" % (url, response.status_code))
-        return response.content
+        
+        return response if stream else response.contentnt
 
     def convert(self, barcodes):
         # Ask Google to move some barcodes from the "Available" state to "In-Process"

--- a/etl-pipeline/processes/grin/grin_client.py
+++ b/etl-pipeline/processes/grin/grin_client.py
@@ -41,7 +41,7 @@ class GRINClient(object):
         if response.status_code != 200:
             raise IOError("%s got %s unexpectedly" % (url, response.status_code))
 
-        return response if stream else response.contentnt
+        return response if stream else response.content
 
     def convert(self, barcodes):
         # Ask Google to move some barcodes from the "Available" state to "In-Process"

--- a/etl-pipeline/processes/grin/grin_client.py
+++ b/etl-pipeline/processes/grin/grin_client.py
@@ -35,12 +35,12 @@ class GRINClient(object):
 
     def get(self, fragment, stream=False, **kwargs):
         url = self._url(fragment)
-        
+
         response = self.session.request("GET", url, stream=stream, **kwargs)
-        
+
         if response.status_code != 200:
             raise IOError("%s got %s unexpectedly" % (url, response.status_code))
-        
+
         return response if stream else response.contentnt
 
     def convert(self, barcodes):

--- a/etl-pipeline/tests/functional/processes/grin/download_test.py
+++ b/etl-pipeline/tests/functional/processes/grin/download_test.py
@@ -22,7 +22,7 @@ def grin_status(db_manager):
         grin_status=GRINStatus(
             barcode=barcode,
             failed_download=0,
-            state=GRINState.PENDING_CONVERSION.value,
+            state=GRINState.CONVERTED.value,
             date_created=datetime(1991, 8, 25),
         ),
     )

--- a/etl-pipeline/tests/functional/processes/grin/download_test.py
+++ b/etl-pipeline/tests/functional/processes/grin/download_test.py
@@ -29,11 +29,13 @@ def grin_status(db_manager):
 
     db_manager.session.add(grin_record)
     db_manager.commit_changes()
-    
+
     yield grin_record.grin_status
 
     db_manager.session.execute(delete(GRINStatus).where(GRINStatus.barcode == barcode))
-    db_manager.session.execute(delete(Record).where(Record.source_id == f"{barcode}|grin"))
+    db_manager.session.execute(
+        delete(Record).where(Record.source_id == f"{barcode}|grin")
+    )
     db_manager.commit_changes()
 
 
@@ -41,21 +43,29 @@ def test_grin_download(s3_manager, grin_status):
     bucket = os.environ["PRIVATE_FILE_BUCKET"]
     grin_download_service = GRINDownloadService(bucket=bucket)
 
-    ocr_dir, mets_file_path = grin_download_service.download_barcode(grin_status.barcode)
+    ocr_dir, mets_file_path = grin_download_service.download_barcode(
+        grin_status.barcode
+    )
 
-    assert_ocr_package_downloaded(s3_manager, bucket, grin_status.barcode, mets_file_path, ocr_dir)
+    assert_ocr_package_downloaded(
+        s3_manager, bucket, grin_status.barcode, mets_file_path, ocr_dir
+    )
     assert_ocr_package_unpacked(s3_manager, bucket, mets_file_path, ocr_dir)
 
     delete_ocr_package(s3_manager, bucket, ocr_dir)
 
 
 def assert_ocr_package_downloaded(s3_manager, bucket, barcode, mets_file_path, ocr_dir):
-    ocr_package_head_response = s3_manager.client.head_object(Bucket=bucket, Key=f"{ocr_dir}{barcode}.tar.gz.gpg")
-    
+    ocr_package_head_response = s3_manager.client.head_object(
+        Bucket=bucket, Key=f"{ocr_dir}{barcode}.tar.gz.gpg"
+    )
+
     assert ocr_package_head_response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-    mets_file_head_response = s3_manager.client.head_object(Bucket=bucket, Key=f"{mets_file_path}")
-    
+    mets_file_head_response = s3_manager.client.head_object(
+        Bucket=bucket, Key=f"{mets_file_path}"
+    )
+
     assert mets_file_head_response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
 
@@ -64,9 +74,11 @@ def assert_ocr_package_unpacked(s3_manager, bucket, mets_file_path, ocr_dir):
         s3_manager.get_object(key=mets_file_path, bucket=bucket)["Body"].read()
     )
 
-    for file in mets_file._map_file_ids().values():        
-        page_head_response = s3_manager.client.head_object(Bucket=bucket, Key=f"{ocr_dir}{file.location}")
-        
+    for file in mets_file._map_file_ids().values():
+        page_head_response = s3_manager.client.head_object(
+            Bucket=bucket, Key=f"{ocr_dir}{file.location}"
+        )
+
         assert page_head_response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
 
@@ -78,11 +90,10 @@ def delete_ocr_package(s3_manager, bucket, ocr_dir):
 
     for page in pages:
         for object in page.get("Contents", []):
-            objects_to_delete.append({'Key': object['Key']})
+            objects_to_delete.append({"Key": object["Key"]})
 
     if objects_to_delete:
         for i in range(0, len(objects_to_delete), 1000):
             s3_manager.client.delete_objects(
-                Bucket=bucket,
-                Delete={'Objects': objects_to_delete[i:i+1000]}
+                Bucket=bucket, Delete={"Objects": objects_to_delete[i : i + 1000]}
             )

--- a/etl-pipeline/tests/functional/processes/grin/download_test.py
+++ b/etl-pipeline/tests/functional/processes/grin/download_test.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+import os
+import pytest
+from sqlalchemy import delete
+from uuid import uuid4
+
+import file_conversion.pdfs.mets_parser as mets_parser
+from processes.grin.download import GRINDownloadService
+from model import Record, FRBRStatus, RecordState, Source, GRINStatus, GRINState
+
+
+@pytest.fixture
+def grin_status(db_manager):
+    barcode = "33433124920780"
+    grin_record = Record(
+        uuid=uuid4(),
+        frbr_status=FRBRStatus.TODO.value,
+        cluster_status=False,
+        state=RecordState.STAGED.value,
+        source_id=f"{barcode}|grin",
+        source=Source.GRIN.value,
+        grin_status=GRINStatus(
+            barcode=barcode,
+            failed_download=0,
+            state=GRINState.PENDING_CONVERSION.value,
+            date_created=datetime(1991, 8, 25),
+        ),
+    )
+
+    db_manager.session.add(grin_record)
+    db_manager.commit_changes()
+    
+    yield grin_record.grin_status
+
+    db_manager.session.execute(delete(GRINStatus).where(GRINStatus.barcode == barcode))
+    db_manager.session.execute(delete(Record).where(Record.source_id == f"{barcode}|grin"))
+    db_manager.commit_changes()
+
+
+def test_grin_download(s3_manager, grin_status):
+    bucket = os.environ["PRIVATE_FILE_BUCKET"]
+    grin_download_service = GRINDownloadService(bucket=bucket)
+
+    ocr_dir, mets_file_path = grin_download_service.download_barcode(grin_status.barcode)
+
+    assert_ocr_package_downloaded(s3_manager, bucket, grin_status.barcode, mets_file_path, ocr_dir)
+    assert_ocr_package_unpacked(s3_manager, bucket, mets_file_path, ocr_dir)
+
+    delete_ocr_package(s3_manager, bucket, ocr_dir)
+
+
+def assert_ocr_package_downloaded(s3_manager, bucket, barcode, mets_file_path, ocr_dir):
+    ocr_package_head_response = s3_manager.client.head_object(Bucket=bucket, Key=f"{ocr_dir}{barcode}.tar.gz.gpg")
+    
+    assert ocr_package_head_response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    mets_file_head_response = s3_manager.client.head_object(Bucket=bucket, Key=f"{mets_file_path}")
+    
+    assert mets_file_head_response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+def assert_ocr_package_unpacked(s3_manager, bucket, mets_file_path, ocr_dir):
+    mets_file = mets_parser.METSFile.from_mets_str(
+        s3_manager.get_object(key=mets_file_path, bucket=bucket)["Body"].read()
+    )
+
+    for file in mets_file._map_file_ids().values():        
+        page_head_response = s3_manager.client.head_object(Bucket=bucket, Key=f"{ocr_dir}{file.location}")
+        
+        assert page_head_response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+def delete_ocr_package(s3_manager, bucket, ocr_dir):
+    paginator = s3_manager.client.get_paginator("list_objects_v2")
+    pages = paginator.paginate(Bucket=bucket, Prefix=ocr_dir)
+
+    objects_to_delete = []
+
+    for page in pages:
+        for object in page.get("Contents", []):
+            objects_to_delete.append({'Key': object['Key']})
+
+    if objects_to_delete:
+        for i in range(0, len(objects_to_delete), 1000):
+            s3_manager.client.delete_objects(
+                Bucket=bucket,
+                Delete={'Objects': objects_to_delete[i:i+1000]}
+            )


### PR DESCRIPTION
## Describe your changes
- Streams tar files from GRIN to reduce memory usage
- Uses temp files to store OCR packages on disk
- Streams to S3

## How to test
`pytest tests/functional/processes/grin/download_test.py -s -vv `