### PR TITLE
SCHOL-71: Test GRIN scrape URL and request

### DIFF
--- a/etl-pipeline/tests/functional/processes/test_grin_scrape.py
+++ b/etl-pipeline/tests/functional/processes/test_grin_scrape.py
@@ -1,16 +1,15 @@
 from processes.grin.grin_client import GRINClient
 
 
-class TestGRINScrape:
-    def test_url_and_request(self):
-        GRIN_SCRAPE_URL = "_all_books?book_state=NEW&book_state=PREVIOUSLY_DOWNLOADED&format=text"  # why previously downloaded?
+def test_url_and_request():
+    GRIN_SCRAPE_URL = (
+        "_all_books?book_state=NEW&book_state=PREVIOUSLY_DOWNLOADED&format=text"
+    )
 
-        grin_client = GRINClient()
-        expected_url = grin_client._url(GRIN_SCRAPE_URL)
-        response = grin_client.session.request("GET", expected_url, timeout=600)
-        response.raise_for_status()  # raises an error for bad responses, otherwise continues
+    grin_client = GRINClient()
+    expected_url = grin_client._url(GRIN_SCRAPE_URL)
+    response = grin_client.session.request("GET", expected_url, timeout=600)
+    response.raise_for_status()
 
-        assert GRIN_SCRAPE_URL in expected_url
-        assert response.content, (
-            "No content returned from GRIN endpoint"
-        )  # assert the response is not empty
+    assert GRIN_SCRAPE_URL in expected_url
+    assert response.content, "No content returned from GRIN endpoint"

--- a/etl-pipeline/tests/functional/processes/test_grin_scrape.py
+++ b/etl-pipeline/tests/functional/processes/test_grin_scrape.py
@@ -1,0 +1,16 @@
+from processes.grin.grin_client import GRINClient
+
+
+class TestGRINScrape:
+    def test_url_and_request(self):
+        GRIN_SCRAPE_URL = "_all_books?book_state=NEW&book_state=PREVIOUSLY_DOWNLOADED&format=text"  # why previously downloaded?
+
+        grin_client = GRINClient()
+        expected_url = grin_client._url(GRIN_SCRAPE_URL)
+        response = grin_client.session.request("GET", expected_url, timeout=600)
+        response.raise_for_status()  # raises an error for bad responses, otherwise continues
+
+        assert GRIN_SCRAPE_URL in expected_url
+        assert response.content, (
+            "No content returned from GRIN endpoint"
+        )  # assert the response is not empty


### PR DESCRIPTION
## Describe your changes
Adds a functional test to verify that the `GRINClient` constructs the correct URL to scrape and successfully issues a GET request.
- Introduces class `TestGRINScrape` with a `test_url_and_request` method
- Constructs the URL to scrape and sends a real HTTP request
- Asserts that the URL contains the expected path and that the response body is non-empty

## How to test
Run `pytest tests/functional/processes/test_grin_scrape.py`
