### PR TITLE
GRIN Ingestion only upload METs

### DIFF
--- a/etl-pipeline/processes/grin/download.py
+++ b/etl-pipeline/processes/grin/download.py
@@ -127,7 +127,7 @@ class GRINDownloadService:
                 for file in tar_file:
                     file_obj = tar_file.extractfile(file)
                     _, extension = os.path.splitext(file.name)
-                    
+
                     # Only upload METs file
                     if extension == ".xml":
                         self.s3_manager.client.upload_fileobj(

--- a/etl-pipeline/processes/grin/download.py
+++ b/etl-pipeline/processes/grin/download.py
@@ -120,14 +120,16 @@ class GRINDownloadService:
         return decrypted_ocr_package
 
     def upload_unpacked_ocr_files(self, barcode, ocr_dir, decrypted_ocr_package):
-        logger.info(f"Unpacking and uploading {barcode} OCR files to s3")
+        logger.info(f"Unpacking and uploading {barcode} METs file to s3")
 
         try:
             with tarfile.open(decrypted_ocr_package, mode="r|*") as tar_file:
                 for file in tar_file:
                     file_obj = tar_file.extractfile(file)
-
-                    if file_obj:
+                    _, extension = os.path.splitext(file.name)
+                    
+                    # Only upload METs file
+                    if extension == ".xml":
                         self.s3_manager.client.upload_fileobj(
                             io.BytesIO(file_obj.read()),
                             Bucket=self.bucket,

--- a/etl-pipeline/processes/grin/download.py
+++ b/etl-pipeline/processes/grin/download.py
@@ -52,7 +52,7 @@ class GRINDownloadService:
             decrypted_ocr_package = self.decrypt_ocr_package(
                 barcode, tmp_ocr_package, tmp_dir
             )
-            self.upload_unpacked_ocr_files(barcode, ocr_dir, decrypted_ocr_package)
+            self.unpack_and_upload_mets_file(barcode, ocr_dir, decrypted_ocr_package)
 
             mets_file = ocr_dir + f"NYPL_{barcode}.xml"
             return ocr_dir, mets_file
@@ -119,7 +119,7 @@ class GRINDownloadService:
 
         return decrypted_ocr_package
 
-    def upload_unpacked_ocr_files(self, barcode, ocr_dir, decrypted_ocr_package):
+    def unpack_and_upload_mets_file(self, barcode, ocr_dir, decrypted_ocr_package):
         logger.info(f"Unpacking and uploading {barcode} METs file to s3")
 
         try:

--- a/etl-pipeline/tests/functional/processes/grin/download_test.py
+++ b/etl-pipeline/tests/functional/processes/grin/download_test.py
@@ -50,7 +50,7 @@ def test_grin_download(s3_manager, grin_status):
     assert_ocr_package_downloaded(
         s3_manager, bucket, grin_status.barcode, mets_file_path, ocr_dir
     )
-    assert_ocr_package_unpacked(s3_manager, bucket, mets_file_path, ocr_dir)
+    assert_mets_file_uploaded(s3_manager, bucket, mets_file_path)
 
     delete_ocr_package(s3_manager, bucket, ocr_dir)
 
@@ -69,17 +69,10 @@ def assert_ocr_package_downloaded(s3_manager, bucket, barcode, mets_file_path, o
     assert mets_file_head_response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
 
-def assert_ocr_package_unpacked(s3_manager, bucket, mets_file_path, ocr_dir):
-    mets_file = mets_parser.METSFile.from_mets_str(
-        s3_manager.get_object(key=mets_file_path, bucket=bucket)["Body"].read()
-    )
+def assert_mets_file_uploaded(s3_manager, bucket, mets_file_path):
+    mets_file = s3_manager.get_object(key=mets_file_path, bucket=bucket)
 
-    for file in mets_file._map_file_ids().values():
-        page_head_response = s3_manager.client.head_object(
-            Bucket=bucket, Key=f"{ocr_dir}{file.location}"
-        )
-
-        assert page_head_response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert mets_file["ResponseMetadata"]["HTTPStatusCode"] == 200
 
 
 def delete_ocr_package(s3_manager, bucket, ocr_dir):


### PR DESCRIPTION
## Describe your changes
This PR updates the GRIN ingestion to only upload the METs file in the unpacked TAR file. This change is to speed up ingestion.

## How to test
I tested this in QA (see here: https://us-east-1.console.aws.amazon.com/s3/buckets/drb-files-limited-qa?region=us-east-1&bucketType=general&prefix=grin/33433124453139/&showversions=false). You can use the same barcode, change the grin state in the DB to converted, and run the GRINIngestProcess on the barcode. 