### PR TITLE
[NO-REF] Switch back to not save HathiTrust files

### DIFF
--- a/etl-pipeline/mappings/hathitrust.py
+++ b/etl-pipeline/mappings/hathitrust.py
@@ -109,14 +109,10 @@ class HathiMapping(CSVMapping):
             file_link = str(
                 Part(
                     index=1,
-                    url=get_stored_file_url(
-                        storage_name=os.environ["FILE_BUCKET"],
-                        file_path=f"pdfs/{Source.HATHI.value}/{self.source[0]}.pdf",
-                    ),
+                    url=f"https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id={file_id}",
                     source=Source.HATHI.value,
                     file_type="application/pdf",
                     flags=str(FileFlags(download=True)),
-                    source_url=f"https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id={file_id}",
                 )
             )
 

--- a/etl-pipeline/tests/unit/mappings/test_hathitrust_mapping.py
+++ b/etl-pipeline/tests/unit/mappings/test_hathitrust_mapping.py
@@ -97,7 +97,7 @@ class TestHathingMapping:
         assert testMapping.record.rights == "hathitrust|test|Test Reason|Test License|"
         assert testMapping.record.has_part == [
             '1|https://babel.hathitrust.org/cgi/pt?id=recordID|hathitrust|text/html|{"embed": true}',
-            '1|https://test_aws_bucket.s3.amazonaws.com/pdfs/hathitrust/recordID.pdf|hathitrust|application/pdf|{"download": true}|https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id=recordID',
+            '1|https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id=recordID|hathitrust|application/pdf|{"download": true}',
         ]
         assert testMapping.record.spatial == "Test Country"
 


### PR DESCRIPTION
## Describe your changes
- HathiTrust is now blocking us from downloading their PDFs
- Switches back to using links instead of storing files within S3