### PR TITLE
Add reader to VRA

### DIFF
--- a/web/src/components/EditionCard/ReadOnlineLink.tsx
+++ b/web/src/components/EditionCard/ReadOnlineLink.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@nypl/design-system-react-components";
+import { Box, Button } from "@nypl/design-system-react-components";
 import React from "react";
 import Link from "~/src/components/Link/Link";
 import { LOGIN_LINK_BASE } from "~/src/constants/links";
@@ -6,6 +6,7 @@ import { ItemLink } from "~/src/types/DataModel";
 import { LOGIN_TO_READ_TEST_ID } from "~/src/constants/testIds";
 import { getHostname } from "~/src/util/LinkUtils";
 import { trackEvent } from "~/src/lib/gtag/Analytics";
+import { useResultPageContext } from "~/src/context/ResultPageContext";
 
 // "Read Online" button should only show up if the link was flagged as "reader" or "embed"
 const ReadOnlineLink: React.FC<{
@@ -14,7 +15,10 @@ const ReadOnlineLink: React.FC<{
   readOnlineLink: ItemLink;
   title: string;
   loginCookie?: any;
-}> = ({  authors, isLoggedIn, readOnlineLink, title }) => {
+}> = ({ authors, isLoggedIn, readOnlineLink, title }) => {
+  const { onReadOnline, page } = useResultPageContext();
+  const isResearchAssistant = page === "researchAssistant";
+
   let linkText = "Read Online";
   let linkUrl: any = {
     pathname: `/read/${readOnlineLink.link_id}`,
@@ -33,25 +37,35 @@ const ReadOnlineLink: React.FC<{
     if (linkUrl.pathname) {
       const hostname = getHostname();
       trackEvent({
-        "event":  "digital_read_online",
-        "item_title": title,
-        "item_author": authors,
-        "read_online_url": `${hostname}${linkUrl.pathname}`
+        event: "digital_read_online",
+        item_title: title,
+        item_author: authors,
+        read_online_url: `${hostname}${linkUrl.pathname}`,
       });
     }
-  }
+  };
 
   return (
     readOnlineLink && (
       <Box data-testid={LOGIN_TO_READ_TEST_ID}>
-        <Link
-          to={linkUrl}
-          linkType="button"
-          aria-label={`${title} ${linkText}`}
-          onClick={trackReadOnlineClick}
-        >
-          {linkText}
-        </Link>
+        {isResearchAssistant ? (
+          <Button
+            id={`read-online-button-${readOnlineLink.link_id}`}
+            onClick={() => onReadOnline(readOnlineLink.link_id)}
+            width="100%"
+          >
+            {linkText}
+          </Button>
+        ) : (
+          <Link
+            to={linkUrl}
+            linkType="button"
+            aria-label={`${title} ${linkText}`}
+            onClick={trackReadOnlineClick}
+          >
+            {linkText}
+          </Link>
+        )}
       </Box>
     )
   );

--- a/web/src/components/ResearchAssistant/ResearchAssistant.tsx
+++ b/web/src/components/ResearchAssistant/ResearchAssistant.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useResearchAssistant } from "./useResearchAssistant";
 import ResearchAssistantWindow from "./ResearchAssistantWindow";
 import ResearchAssistantInput from "./ResearchAssistantInput";
@@ -8,11 +8,15 @@ import {
   Box,
   Button,
   Heading,
-  TemplateAppContainer,
   Text,
 } from "@nypl/design-system-react-components";
 import DrbBreakout from "../DrbBreakout/DrbBreakout";
 import DrbHero from "../DrbHero/DrbHero";
+import ResearchAssistantNav from "./ResearchAssistantNav";
+import { ResultPageProvider } from "~/src/context/ResultPageContext";
+import ReaderLayout from "../ReaderLayout/ReaderLayout";
+import { proxyUrlConstructor, readFetcher } from "~/src/lib/api/SearchApi";
+import { LinkResult } from "~/src/types/LinkQuery";
 
 const ResearchAssistant: React.FC = () => {
   const {
@@ -24,6 +28,8 @@ const ResearchAssistant: React.FC = () => {
     clearHistory,
   } = useResearchAssistant();
 
+  const [showWebReader, setShowWebReader] = useState(false);
+  const [linkResults, setLinkResults] = useState<LinkResult>();
 
   useEffect(() => {
     const initialMessage = sessionStorage.getItem(
@@ -35,74 +41,104 @@ const ResearchAssistant: React.FC = () => {
     }
   }, [sendMessage]);
 
-  const breakoutElement = (
-    <DrbBreakout
-      breadcrumbsData={[
-        { url: "/research-assistant", text: "Virtual Research Assistant" },
-      ]}
-    >
-      <DrbHero />
-    </DrbBreakout>
-  );
+  const handleReadOnline = async (linkId: number) => {
+    setShowWebReader(true);
+    const linkResult: LinkResult = await readFetcher(linkId);
+    setLinkResults(linkResult);
+  };
 
-  const contentPrimaryElement = (
-    <Box className={styles.pageContainer}>
-      {results && (
-        <Box className={styles.resultsPanel}>
-          {results.totalWorks ? (
-            <Heading
-              level="h3"
-              size="heading5"
-              className={styles.resultsHeader}
-            >
-              <>{results.totalWorks} results matching your research criteria</>
-            </Heading>
-          ) : null}
-
-          <ResultsList works={results.works} />
-        </Box>
-      )}
-
-      <section className={styles.chatPanel}>
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          alignItems="center"
-          paddingX="l"
-          paddingY="s"
-          borderBottom="1px white solid"
-        >
-          <Heading level="h2" size="heading3" color="ui.white" margin="0">
-            Virtual Research Assistant
-          </Heading>
-          <Button
-            onClick={clearHistory}
-            className={styles.clearButton}
-            id="clear-history-button"
-          >
-            Clear chat
-          </Button>
-        </Box>
-
-        <ResearchAssistantWindow messages={messages} isLoading={isLoading} />
-
-        {error && <Text className={styles.errorText}>{error}</Text>}
-
-        <ResearchAssistantInput
-          onSendMessage={sendMessage}
-          isDisabled={isLoading}
-          messages={messages}
-        />
-      </section>
-    </Box>
-  );
+  const proxyUrl: string = proxyUrlConstructor();
+  const backUrl = "/research-assistant";
 
   return (
-    <TemplateAppContainer
-      breakout={breakoutElement}
-      contentPrimary={contentPrimaryElement}
-      gridTemplateColumns="1fr 100% 1fr"
-    />
+    <ResultPageProvider
+      value={{ onReadOnline: handleReadOnline, page: "researchAssistant" }}
+    >
+      <DrbBreakout
+        breadcrumbsData={[
+          { url: "/research-assistant", text: "Virtual Research Assistant" },
+        ]}
+      >
+        <DrbHero />
+        <ResearchAssistantNav />
+      </DrbBreakout>
+
+      <Box className={styles.pageContainer}>
+        {results && (
+          <Box className={styles.resultsPanel}>
+            {showWebReader ? (
+              linkResults && (
+                <Box position="relative">
+                  <Button
+                    onClick={() => setShowWebReader(false)}
+                    id="close-reader-button"
+                    position="absolute"
+                    right="s"
+                    top="s"
+                  >
+                    Close reader
+                  </Button>
+                  <ReaderLayout
+                    linkResult={linkResults}
+                    proxyUrl={proxyUrl}
+                    backUrl={backUrl}
+                  />
+                </Box>
+              )
+            ) : (
+              <>
+                {results.totalWorks ? (
+                  <Heading
+                    level="h3"
+                    size="heading5"
+                    className={styles.resultsHeader}
+                  >
+                    <>
+                      {results.totalWorks} results matching your research
+                      criteria
+                    </>
+                  </Heading>
+                ) : null}
+
+                <ResultsList works={results.works} />
+              </>
+            )}
+          </Box>
+        )}
+
+        <section className={styles.chatPanel}>
+          <Box
+            display="flex"
+            justifyContent="space-between"
+            alignItems="center"
+            paddingX="l"
+            paddingY="s"
+            borderBottom="1px white solid"
+          >
+            <Heading level="h2" size="heading3" color="ui.white" margin="0">
+              Virtual Research Assistant
+            </Heading>
+            <Button
+              onClick={clearHistory}
+              className={styles.clearButton}
+              id="clear-history-button"
+            >
+              Clear chat
+            </Button>
+          </Box>
+
+          <ResearchAssistantWindow messages={messages} isLoading={isLoading} />
+
+          {error && <Text className={styles.errorText}>{error}</Text>}
+
+          <ResearchAssistantInput
+            onSendMessage={sendMessage}
+            isDisabled={isLoading}
+            messages={messages}
+          />
+        </section>
+      </Box>
+    </ResultPageProvider>
   );
 };
 

--- a/web/src/components/ResearchAssistant/ResearchAssistantLanding.tsx
+++ b/web/src/components/ResearchAssistant/ResearchAssistantLanding.tsx
@@ -12,6 +12,7 @@ import ResearchAssistantIcon from "./ResearchAssistantIcon";
 import DrbBreakout from "../DrbBreakout/DrbBreakout";
 import DrbHero from "../DrbHero/DrbHero";
 import { useRouter } from "next/router";
+import ResearchAssistantNav from "./ResearchAssistantNav";
 
 const ResearchAssistantLanding: React.FC = () => {
     const router = useRouter();
@@ -70,38 +71,7 @@ const ResearchAssistantLanding: React.FC = () => {
                 ]}
             >
                 <DrbHero />
-                <Box
-                    height="l"
-                    paddingY="xs"
-                    display="flex"
-                    maxWidth="1280px"
-                    alignItems="center"
-                    margin="auto"
-                    gap="s"
-                >
-                    <Box
-                        display="flex"
-                        alignItems="center"
-                        paddingX="s"
-                        paddingY="xxs"
-                        backgroundColor="section.research.primary-05"
-                        borderRadius="6px"
-                    >
-                        <ResearchAssistantIcon />
-                        <Text
-                            size="body1"
-                            color="section.research.secondary"
-                            isBold
-                            noSpace
-                        >
-                            Virtual Research Assistant
-                        </Text>
-                    </Box>
-                    <Box display="flex" alignItems="center">
-                        <Icon name="search" align="left" size="large" />
-                        <Text noSpace>Keyword search</Text>
-                    </Box>
-                </Box>
+                <ResearchAssistantNav />
             </DrbBreakout>
 
             <Box display="flex" flexDir="column">

--- a/web/src/components/ResearchAssistant/ResearchAssistantNav.tsx
+++ b/web/src/components/ResearchAssistant/ResearchAssistantNav.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import {
+    Box,
+    Text,
+    Icon,
+} from "@nypl/design-system-react-components";
+import ResearchAssistantIcon from "./ResearchAssistantIcon";
+
+const ResearchAssistantNav: React.FC = () => {
+    return (
+        <Box borderBottom="1px solid" borderColor="section.research.secondary">
+            <Box
+                height="l"
+                paddingY="xs"
+                display="flex"
+                maxWidth="1280px"
+                alignItems="center"
+                margin="auto"
+                gap="s"
+            >
+                <Box
+                    display="flex"
+                    alignItems="center"
+                    paddingX="s"
+                    paddingY="xxs"
+                    backgroundColor="section.research.primary-05"
+                    borderRadius="6px"
+                >
+                    <ResearchAssistantIcon />
+                    <Text
+                        size="body1"
+                        color="section.research.secondary"
+                        isBold
+                        noSpace
+                    >
+                        Virtual Research Assistant
+                    </Text>
+                </Box>
+                <Box display="flex" alignItems="center">
+                    <Icon name="search" align="left" size="large" />
+                    <Text noSpace>Keyword search</Text>
+                </Box>
+            </Box>
+        </Box>
+
+    );
+};
+
+export default ResearchAssistantNav;

--- a/web/src/context/ResultPageContext.tsx
+++ b/web/src/context/ResultPageContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useState } from "react";
+
+type PageType = "keyword" | "researchAssistant";
+
+type ResultPageContextType = {
+    onReadOnline: (linkId: number) => void;
+    page: PageType;
+};
+
+const ResultPageContext = createContext<ResultPageContextType>({
+    onReadOnline: () => { },
+    page: "keyword",
+});
+
+export const ResultPageProvider: React.FC<{
+    children?: React.ReactNode;
+    value: ResultPageContextType;
+}> = ({ children, value }) => {
+    return (
+        <ResultPageContext.Provider value={value}>
+            {children}
+        </ResultPageContext.Provider>
+    );
+};
+
+export function useResultPageContext() {
+    const context = useContext(ResultPageContext);
+    if (context === null) {
+        throw new Error(
+            "useResultPageContext must be used within a ResultPageProvider"
+        );
+    }
+    return context;
+}

--- a/web/styles/components/ResearchAssistant.module.scss
+++ b/web/styles/components/ResearchAssistant.module.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: row;
   overflow: hidden;
-  gap: 20px;
 }
 
 .resultsPanel {


### PR DESCRIPTION
## Describe your changes
**Note**: The `/chats` API is not returning the readable link, so clicking on the "Read online" button will show the embeddable reader.

- Adds reader layout to VRA when "Read online" button is clicked. A React context was added to handle the behavior of the "Read online" button (linking to `/read/{id}` page is default for all pages, excluding the research assistant)
- Adds temporary "Close reader" button at top right to go back to search results (this will be updated in the future to be within the WebReader back button)
- Moves research assistant navbar to a separate component

<img width="1576" height="757" alt="image" src="https://github.com/user-attachments/assets/03f70725-d761-4836-b205-14dafa5bbdf8" />
<img width="1579" height="922" alt="image" src="https://github.com/user-attachments/assets/4377d120-3cda-4638-a817-35bc8ec648cf" />


## How to test
