### PR TITLE
NOREF Updates based on local development

### DIFF
--- a/etl-pipeline/README.md
+++ b/etl-pipeline/README.md
@@ -143,6 +143,11 @@ Execute the command in your terminal. You will be prompted to enter your credent
 aws configure 
 ```
 
+## Install GPG (if working with Google Books)
+The process for working with books downloaded from Google's GRIN interface requires a decryption step via `gpg`
+
+Ensure that it is available by installing it via `brew` (if on a Mac) or the appropiate tool for your OS
+
 ### Running Individual Processes
 
 While Docker handles the main services, you can run individual processes using:

--- a/etl-pipeline/processes/grin/conversion.py
+++ b/etl-pipeline/processes/grin/conversion.py
@@ -132,8 +132,12 @@ class GRINConversion:
             )
 
             self.logger.info(f"Converting {len(failed_barcodes)} failed conversions")
-            converting_barcodes, *_ = self._convert_barcodes(failed_barcodes)
-            self._update_grin_date_modified(converting_barcodes)
+
+            if len(failed_barcodes) > 0:
+                converting_barcodes, *_ = self._convert_barcodes(failed_barcodes)
+                self._update_grin_date_modified(converting_barcodes)
+            else:
+                self.logger.info("No failed conversion barcodes from last two weeks")
 
     def _sync_converted_books(self) -> set:
         converted_filenames = self.client.converted_filenames()
@@ -164,19 +168,17 @@ class GRINConversion:
                     .all()
                 )
 
-                if not barcodes_to_update:
-                    continue
+                if barcodes_to_update:
+                    update_results = self.db_manager.session.execute(
+                        update(GRINStatus)
+                        .filter(GRINStatus.barcode.in_(barcodes_to_update))
+                        .values(state=GRINState.CONVERTED.value)
+                    )
 
-                update_results = self.db_manager.session.execute(
-                    update(GRINStatus)
-                    .filter(GRINStatus.barcode.in_(barcodes_to_update))
-                    .values(state=GRINState.CONVERTED.value)
-                )
+                    self.db_manager.commit_changes()
 
-                self.db_manager.commit_changes()
-
-                self.logger.info(f"Converted {update_results.rowcount} barcodes")
-                newly_converted_barcodes.update(barcodes_to_update)
+                    self.logger.info(f"Converted {update_results.rowcount} barcodes")
+                    newly_converted_barcodes.update(barcodes_to_update)
             except Exception:
                 self.db_manager.session.rollback()
                 self.logger.exception(


### PR DESCRIPTION
This branch contains a few updates I came across while working on running GRIN processes locally. Wanted to put them up as part of getting ready to onboard new folks

1) Call out the need for `gpg` to be installed locally for GRIN decryption
2) Fixed a bug in the conversion process that caused a crash if no failed barcodes were avialble to retry
3) Fixed a bug that caused new barcodes to be skipped if no barcodes were available to be updated in the converted books method
