### PR TITLE
SCHOL-120: Add unpacking service for web reader

### DIFF
--- a/etl-pipeline/api/blueprints/item_read.py
+++ b/etl-pipeline/api/blueprints/item_read.py
@@ -110,12 +110,11 @@ def _find_files_from_list_objects(file_list, page_id):
 def _find_files_from_dict(file_dict, page_id):
     ocr_key = f"{page_id}.html" if f"{page_id}.html" in file_dict else None
 
-    for k in file_dict.keys():
-        if (
-            k.lower().endswith((".png", ".jpg", ".jpeg", ".tiff", ".tif", ".jp2"))
-            and page_id in k
-        ):
-            image_key = k
+    for suffix in [".png", ".jpg", ".jpeg", ".tiff", ".tif", ".jp2"]:
+        if f"{page_id}{suffix}" in file_dict:
+            image_key = f"{page_id}{suffix}"
             break
+        else:
+            image_key = None
 
     return ocr_key, image_key

--- a/etl-pipeline/api/blueprints/item_read.py
+++ b/etl-pipeline/api/blueprints/item_read.py
@@ -8,6 +8,7 @@ from .items import items_blueprint
 import file_conversion.pdfs.mets_parser as mets_parser
 from managers import DBManager, S3Manager
 from model import Item, Record
+from processes.grin.unpack import GRINUnpackService
 
 RESPONSE_TYPE = "itemRead"
 
@@ -41,35 +42,33 @@ def item_read(item_id, page_id):
     response = storage_manager.client.list_objects_v2(Bucket=bucket, Prefix=prefix)
     files = [obj["Key"] for obj in response.get("Contents", [])]
 
-    ocr_key = next((f for f in files if f.endswith("html")), None)
-    image_key = next(
-        (
-            f
-            for f in files
-            if f.lower().endswith((".png", ".jpg", ".jpeg", ".tiff", ".tif", ".jp2"))
-        ),
-        None,
-    )
-
-    if not ocr_key or not image_key:
-        return APIUtils.formatResponseObject(
-            404, RESPONSE_TYPE, {"message": "Page not found"}
-        )
+    ocr_key, image_key = _find_files(files)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        ocr_path = os.path.join(tmpdir, os.path.basename(ocr_key))
-        image_path = os.path.join(tmpdir, os.path.basename(image_key))
+        if not ocr_key or not image_key:
+            unpack_service = GRINUnpackService(bucket)
+            unpacked_files = unpack_service.unpack_barcode_package(barcode)
+            ocr_key, image_key = _find_files(unpacked_files.keys(), page_id=page_id)
 
-        storage_manager.client.download_file(bucket, ocr_key, ocr_path)
-        storage_manager.client.download_file(bucket, image_key, image_path)
+            if not ocr_key or not image_key:
+                return APIUtils.formatResponseObject(
+                    404, RESPONSE_TYPE, {"message": "Page not found"}
+                )
 
-        pdf_path = os.path.join(tmpdir, f"{page_id}.pdf")
+            ocr_path = os.path.join(tmpdir, os.path.basename(ocr_key))
+            image_path = os.path.join(tmpdir, os.path.basename(image_key))
 
-        hocr_transform = HocrTransform(hocr_filename=ocr_path, dpi=300)
-        hocr_transform.to_pdf(out_filename=pdf_path, image_filename=image_path)
+            with open(ocr_path, "wb") as f:
+                f.write(unpacked_files[ocr_key])
+            with open(image_path, "wb") as f:
+                f.write(unpacked_files[image_key])
+        else:
+            ocr_path = os.path.join(tmpdir, os.path.basename(ocr_key))
+            image_path = os.path.join(tmpdir, os.path.basename(image_key))
+            storage_manager.client.download_file(bucket, ocr_key, ocr_path)
+            storage_manager.client.download_file(bucket, image_key, image_path)
 
-        with open(pdf_path, "rb") as f:
-            pdf_data = f.read()
+        pdf_data = _create_pdf_from_paths(ocr_path, image_path, page_id)
 
     return APIUtils.formatResponseObject(
         200,
@@ -82,3 +81,33 @@ def item_read(item_id, page_id):
             "nextPages": next_pages,
         },
     )
+
+
+def _create_pdf_from_paths(ocr_path, image_path, page_id):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pdf_path = os.path.join(tmpdir, f"{page_id}.pdf")
+        hocr_transform = HocrTransform(hocr_filename=ocr_path, dpi=300)
+        hocr_transform.to_pdf(out_filename=pdf_path, image_filename=image_path)
+        with open(pdf_path, "rb") as f:
+            return f.read()
+
+
+def _find_files(file_list, page_id=None):
+    ocr_key = next(
+        (
+            f
+            for f in file_list
+            if f.endswith("html") and (page_id is None or page_id in f)
+        ),
+        None,
+    )
+    image_key = next(
+        (
+            f
+            for f in file_list
+            if f.lower().endswith((".png", ".jpg", ".jpeg", ".tiff", ".tif", ".jp2"))
+            and (page_id is None or page_id in f)
+        ),
+        None,
+    )
+    return ocr_key, image_key

--- a/etl-pipeline/api/blueprints/item_read.py
+++ b/etl-pipeline/api/blueprints/item_read.py
@@ -42,13 +42,13 @@ def item_read(item_id, page_id):
     response = storage_manager.client.list_objects_v2(Bucket=bucket, Prefix=prefix)
     files = [obj["Key"] for obj in response.get("Contents", [])]
 
-    ocr_key, image_key = _find_files(files)
+    ocr_key, image_key = _find_files_from_list_objects(files, page_id)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         if not ocr_key or not image_key:
             unpack_service = GRINUnpackService(bucket)
             unpacked_files = unpack_service.unpack_barcode_package(barcode)
-            ocr_key, image_key = _find_files(unpacked_files.keys(), page_id=page_id)
+            ocr_key, image_key = _find_files_from_dict(unpacked_files, page_id)
 
             if not ocr_key or not image_key:
                 return APIUtils.formatResponseObject(
@@ -92,22 +92,30 @@ def _create_pdf_from_paths(ocr_path, image_path, page_id):
             return f.read()
 
 
-def _find_files(file_list, page_id=None):
-    ocr_key = next(
-        (
-            f
-            for f in file_list
-            if f.endswith("html") and (page_id is None or page_id in f)
-        ),
-        None,
-    )
+def _find_files_from_list_objects(file_list, page_id):
+    ocr_key = next((f for f in file_list if f.endswith("html") and page_id in f), None)
     image_key = next(
         (
             f
             for f in file_list
             if f.lower().endswith((".png", ".jpg", ".jpeg", ".tiff", ".tif", ".jp2"))
-            and (page_id is None or page_id in f)
+            and page_id in f
         ),
         None,
     )
+
+    return ocr_key, image_key
+
+
+def _find_files_from_dict(file_dict, page_id):
+    ocr_key = f"{page_id}.html" if f"{page_id}.html" in file_dict else None
+
+    for k in file_dict.keys():
+        if (
+            k.lower().endswith((".png", ".jpg", ".jpeg", ".tiff", ".tif", ".jp2"))
+            and page_id in k
+        ):
+            image_key = k
+            break
+
     return ocr_key, image_key

--- a/etl-pipeline/api/blueprints/item_read.py
+++ b/etl-pipeline/api/blueprints/item_read.py
@@ -98,7 +98,7 @@ def _find_files_from_list_objects(file_list, page_id):
         (
             f
             for f in file_list
-            if f.lower().endswith((".png", ".jpg", ".jpeg", ".tiff", ".tif", ".jp2"))
+            if f.lower().endswith((".tif", ".jp2", ".png", ".jpg", ".jpeg", ".tiff"))
             and page_id in f
         ),
         None,
@@ -110,7 +110,7 @@ def _find_files_from_list_objects(file_list, page_id):
 def _find_files_from_dict(file_dict, page_id):
     ocr_key = f"{page_id}.html" if f"{page_id}.html" in file_dict else None
 
-    for suffix in [".png", ".jpg", ".jpeg", ".tiff", ".tif", ".jp2"]:
+    for suffix in [".tif", ".jp2", ".png", ".jpg", ".jpeg", ".tiff"]:
         if f"{page_id}{suffix}" in file_dict:
             image_key = f"{page_id}{suffix}"
             break

--- a/etl-pipeline/processes/grin/unpack.py
+++ b/etl-pipeline/processes/grin/unpack.py
@@ -82,7 +82,6 @@ class GRINUnpackService:
             return
         except ClientError as e:
             if e.response["Error"]["Code"] == "404":
-                expiration_time = datetime.now(timezone.utc) + timedelta(weeks=1)
                 self.s3_manager.client.put_object(
                     Body=file_data,
                     Bucket=self.bucket,

--- a/etl-pipeline/processes/grin/unpack.py
+++ b/etl-pipeline/processes/grin/unpack.py
@@ -7,6 +7,7 @@ import tarfile
 from botocore.exceptions import ClientError
 from datetime import datetime, timedelta, timezone
 from processes.grin.download import GRINDownloadService
+from utils.profiler import profile
 from managers import S3Manager
 from logger import create_log
 
@@ -30,6 +31,7 @@ class GRINUnpackService:
         self.download_service = GRINDownloadService(bucket)
         self.s3_manager = S3Manager()
 
+    @profile(logger=logger)
     def unpack_barcode_package(self, barcode):
         barcode = str(barcode)
         ocr_dir = f"grin/{barcode}/"

--- a/etl-pipeline/processes/grin/unpack.py
+++ b/etl-pipeline/processes/grin/unpack.py
@@ -1,17 +1,23 @@
+import concurrent.futures
 import os
 import tempfile
 import tarfile
 
+from botocore.exceptions import ClientError
+from datetime import datetime, timedelta, timezone
 from processes.grin.download import GRINDownloadService
+from managers import S3Manager
 from logger import create_log
 
 logger = create_log(__name__)
 
+executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
 
 class GRINUnpackService:
     def __init__(self, bucket):
         self.bucket = bucket
         self.download_service = GRINDownloadService(bucket)
+        self.s3_manager = S3Manager()
 
     def unpack_barcode_package(self, barcode):
         barcode = str(barcode)
@@ -21,7 +27,7 @@ class GRINUnpackService:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_ocr_package = os.path.join(tmp_dir, ocr_package_name)
             logger.info(f"Downloading {ocr_package_name} from S3 bucket {self.bucket}")
-            self.download_service.s3_manager.client.download_file(
+            self.s3_manager.client.download_file(
                 Bucket=self.bucket,
                 Key=f"{ocr_dir}{ocr_package_name}",
                 Filename=tmp_ocr_package,
@@ -37,10 +43,41 @@ class GRINUnpackService:
                     for member in tar:
                         if member.isfile():
                             file_obj = tar.extractfile(member)
-                            files[member.name] = file_obj.read()
-                logger.info(f"Unpacked {len(files)} files for barcode {barcode}")
+                            file_data = file_obj.read()
+                            files[member.name] = file_data
+
+                            executor.submit(
+                                self._upload_file_to_s3,
+                                ocr_dir,
+                                member.name,
+                                file_data,
+                            )
+
+                logger.info(
+                    f"Unpacked and started uploads for {len(files)} files for barcode {barcode}"
+                )
             except tarfile.TarError as e:
                 logger.error(f"Error unpacking OCR package for {barcode}: {e}")
                 raise Exception(f"Failed to unpack OCR package for {barcode}")
 
             return files
+
+    def _upload_file_to_s3(self, ocr_dir, file_name, file_data):
+        s3_key = f"{ocr_dir}{file_name}"
+        try:
+            self.s3_manager.client.head_object(Bucket=self.bucket, Key=s3_key)
+            logger.info(f"File {s3_key} already exists in S3, skipping upload.")
+            return
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "404":
+                expiration_time = datetime.now(timezone.utc) + timedelta(weeks=1)
+                self.s3_manager.client.put_object(
+                    Body=file_data,
+                    Bucket=self.bucket,
+                    Key=s3_key,
+                    Expires=expiration_time,
+                )
+                logger.info(f"Uploaded {file_name} to S3.")
+            else:
+                logger.error(f"Failed to upload {file_name} to S3: {e}")
+                raise

--- a/etl-pipeline/processes/grin/unpack.py
+++ b/etl-pipeline/processes/grin/unpack.py
@@ -13,7 +13,7 @@ from logger import create_log
 
 logger = create_log(__name__)
 
-executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+executor = concurrent.futures.ThreadPoolExecutor(max_workers=8)
 
 
 def shutdown_executor():

--- a/etl-pipeline/processes/grin/unpack.py
+++ b/etl-pipeline/processes/grin/unpack.py
@@ -87,7 +87,7 @@ class GRINUnpackService:
                     Body=file_data,
                     Bucket=self.bucket,
                     Key=s3_key,
-                    Expires=expiration_time,
+                    Tagging="retention=7days",
                 )
                 logger.info(f"Uploaded {file_name} to S3.")
             else:

--- a/etl-pipeline/processes/grin/unpack.py
+++ b/etl-pipeline/processes/grin/unpack.py
@@ -1,0 +1,46 @@
+import os
+import tempfile
+import tarfile
+
+from processes.grin.download import GRINDownloadService
+from logger import create_log
+
+logger = create_log(__name__)
+
+
+class GRINUnpackService:
+    def __init__(self, bucket):
+        self.bucket = bucket
+        self.download_service = GRINDownloadService(bucket)
+
+    def unpack_barcode_package(self, barcode):
+        barcode = str(barcode)
+        ocr_dir = f"grin/{barcode}/"
+        ocr_package_name = f"{barcode}.tar.gz.gpg"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_ocr_package = os.path.join(tmp_dir, ocr_package_name)
+            logger.info(f"Downloading {ocr_package_name} from S3 bucket {self.bucket}")
+            self.download_service.s3_manager.client.download_file(
+                Bucket=self.bucket,
+                Key=f"{ocr_dir}{ocr_package_name}",
+                Filename=tmp_ocr_package,
+            )
+
+            decrypted_ocr_package = self.download_service.decrypt_ocr_package(
+                barcode, tmp_ocr_package, tmp_dir
+            )
+
+            files = {}
+            try:
+                with tarfile.open(decrypted_ocr_package, mode="r|*") as tar:
+                    for member in tar:
+                        if member.isfile():
+                            file_obj = tar.extractfile(member)
+                            files[member.name] = file_obj.read()
+                logger.info(f"Unpacked {len(files)} files for barcode {barcode}")
+            except tarfile.TarError as e:
+                logger.error(f"Error unpacking OCR package for {barcode}: {e}")
+                raise Exception(f"Failed to unpack OCR package for {barcode}")
+
+            return files

--- a/etl-pipeline/processes/grin/unpack.py
+++ b/etl-pipeline/processes/grin/unpack.py
@@ -17,7 +17,6 @@ executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
 
 
 def shutdown_executor():
-    logger.info("Shutting down ThreadPoolExecutor...")
     executor.shutdown(wait=True)
 
 

--- a/etl-pipeline/processes/grin/unpack.py
+++ b/etl-pipeline/processes/grin/unpack.py
@@ -1,3 +1,4 @@
+import atexit
 import concurrent.futures
 import os
 import tempfile
@@ -12,6 +13,14 @@ from logger import create_log
 logger = create_log(__name__)
 
 executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+
+
+def shutdown_executor():
+    logger.info("Shutting down ThreadPoolExecutor...")
+    executor.shutdown(wait=True)
+
+
+atexit.register(shutdown_executor)
 
 
 # TODO: Investigate rework to avoid temporary file I/O and handle potential memory leaks.
@@ -82,4 +91,4 @@ class GRINUnpackService:
                 logger.info(f"Uploaded {file_name} to S3.")
             else:
                 logger.error(f"Failed to upload {file_name} to S3: {e}")
-                raise ClientError
+                raise e

--- a/etl-pipeline/processes/grin/unpack.py
+++ b/etl-pipeline/processes/grin/unpack.py
@@ -82,4 +82,4 @@ class GRINUnpackService:
                 logger.info(f"Uploaded {file_name} to S3.")
             else:
                 logger.error(f"Failed to upload {file_name} to S3: {e}")
-                raise
+                raise ClientError

--- a/etl-pipeline/processes/grin/unpack.py
+++ b/etl-pipeline/processes/grin/unpack.py
@@ -14,6 +14,7 @@ logger = create_log(__name__)
 executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
 
 
+# TODO: Investigate rework to avoid temporary file I/O and handle potential memory leaks.
 class GRINUnpackService:
     def __init__(self, bucket):
         self.bucket = bucket

--- a/etl-pipeline/processes/grin/unpack.py
+++ b/etl-pipeline/processes/grin/unpack.py
@@ -13,6 +13,7 @@ logger = create_log(__name__)
 
 executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
 
+
 class GRINUnpackService:
     def __init__(self, bucket):
         self.bucket = bucket

--- a/etl-pipeline/tests/unit/grin/test_unpack.py
+++ b/etl-pipeline/tests/unit/grin/test_unpack.py
@@ -135,16 +135,7 @@ def test_upload_file_to_s3_success(mock_unpack_service):
     assert kwargs["Body"] == file_data
     assert kwargs["Bucket"] == service.bucket
     assert kwargs["Key"] == "test_dir/test_file.txt"
-
-    expiration_time = kwargs["Expires"]
-    assert isinstance(expiration_time, datetime)
-    time_difference = expiration_time - datetime.now(timezone.utc)
-    assert (
-        timedelta(weeks=1) - timedelta(minutes=5)
-        < time_difference
-        < timedelta(weeks=1) + timedelta(minutes=5)
-    )
-
+    assert kwargs["Tagging"] == "retention=7days"
 
 def test_upload_file_to_s3_skip_existing(mock_unpack_service):
     service, mock_s3_client, _ = mock_unpack_service

--- a/etl-pipeline/tests/unit/grin/test_unpack.py
+++ b/etl-pipeline/tests/unit/grin/test_unpack.py
@@ -31,13 +31,11 @@ def test_unpack_barcode_package_success(mock_unpack_service, mocker):
     ocr_package_name = f"{barcode}.tar.gz.gpg"
     decrypted_package_path = f"/tmp/decrypted/{barcode}.tar.gz"
 
-    _original_path_join = os.path.join
-
     mock_path_join = mocker.patch(
         "processes.grin.unpack.os.path.join",
         side_effect=lambda *args: "/mocked/temp/path/file.tar.gz.gpg"
         if args[1] == ocr_package_name
-        else _original_path_join(*args),
+        else os.path.join(*args),
     )
 
     mock_tmp_dir = mocker.patch("processes.grin.unpack.tempfile.TemporaryDirectory")
@@ -69,7 +67,7 @@ def test_unpack_barcode_package_success(mock_unpack_service, mocker):
         {"Error": {"Code": "404", "Message": "Not Found"}}, "head_object"
     )
 
-    result = service.unpack_barcode_package(barcode)
+    unpacked_files = service.unpack_barcode_package(barcode)
 
     mock_s3_client.download_file.assert_called_once_with(
         Bucket=service.bucket,
@@ -96,7 +94,7 @@ def test_unpack_barcode_package_success(mock_unpack_service, mocker):
         "file1.txt": b"content of file 1",
         "file2.jpg": b"content of file 2",
     }
-    assert result == expected_files
+    assert unpacked_files == expected_files
 
 
 def test_unpack_barcode_package_tar_error(mock_unpack_service, mocker):

--- a/etl-pipeline/tests/unit/grin/test_unpack.py
+++ b/etl-pipeline/tests/unit/grin/test_unpack.py
@@ -32,10 +32,15 @@ def test_unpack_barcode_package_success(mock_unpack_service, mocker):
     decrypted_package_path = f"/tmp/decrypted/{barcode}.tar.gz"
 
     real_join = os.path.join
-    def mock_join(*args):
-        return '/mocked/temp/path/file.tar.gz.gpg' if args[1] == ocr_package_name else real_join(*args)
 
-    mocker.patch('processes.grin.unpack.os.path.join', side_effect=mock_join)
+    def mock_join(*args):
+        return (
+            "/mocked/temp/path/file.tar.gz.gpg"
+            if args[1] == ocr_package_name
+            else real_join(*args)
+        )
+
+    mocker.patch("processes.grin.unpack.os.path.join", side_effect=mock_join)
 
     mock_download_service.decrypt_ocr_package.return_value = decrypted_package_path
 

--- a/etl-pipeline/tests/unit/grin/test_unpack.py
+++ b/etl-pipeline/tests/unit/grin/test_unpack.py
@@ -1,0 +1,170 @@
+import os
+import tarfile
+from datetime import datetime, timedelta, timezone
+import pytest
+from botocore.exceptions import ClientError
+
+from processes.grin.unpack import GRINUnpackService
+
+
+@pytest.fixture
+def mock_unpack_service(mocker):
+    mock_download_service_class = mocker.patch(
+        "processes.grin.unpack.GRINDownloadService"
+    )
+    mock_s3_manager_class = mocker.patch("processes.grin.unpack.S3Manager")
+
+    mock_s3_client = mock_s3_manager_class.return_value.client
+    mock_download_service = mock_download_service_class.return_value
+
+    bucket = "test-bucket"
+    service = GRINUnpackService(bucket)
+
+    return service, mock_s3_client, mock_download_service
+
+
+def test_unpack_barcode_package_success(mock_unpack_service, mocker):
+    service, mock_s3_client, mock_download_service = mock_unpack_service
+
+    barcode = "12345"
+    ocr_dir = f"grin/{barcode}/"
+    ocr_package_name = f"{barcode}.tar.gz.gpg"
+    decrypted_package_path = f"/tmp/decrypted/{barcode}.tar.gz"
+
+    _original_path_join = os.path.join
+
+    mock_path_join = mocker.patch(
+        "processes.grin.unpack.os.path.join",
+        side_effect=lambda *args: "/mocked/temp/path/file.tar.gz.gpg"
+        if args[1] == ocr_package_name
+        else _original_path_join(*args),
+    )
+
+    mock_tmp_dir = mocker.patch("processes.grin.unpack.tempfile.TemporaryDirectory")
+    tmp_dir_path = mock_tmp_dir.return_value.__enter__.return_value
+
+    mock_download_service.decrypt_ocr_package.return_value = decrypted_package_path
+
+    mock_member_1 = mocker.MagicMock(spec=tarfile.TarInfo, isfile=lambda: True)
+    mock_member_1.name = "file1.txt"
+    mock_member_2 = mocker.MagicMock(spec=tarfile.TarInfo, isfile=lambda: True)
+    mock_member_2.name = "file2.jpg"
+
+    mock_tarfile_open = mocker.patch("processes.grin.unpack.tarfile.open")
+
+    mock_tar_obj = mocker.MagicMock()
+    mock_tar_obj.__enter__.return_value = mock_tar_obj
+    mock_tar_obj.__iter__.return_value = [mock_member_1, mock_member_2]
+
+    mock_tar_obj.extractfile.side_effect = [
+        mocker.mock_open(read_data=b"content of file 1").return_value,
+        mocker.mock_open(read_data=b"content of file 2").return_value,
+    ]
+
+    mock_tarfile_open.return_value = mock_tar_obj
+
+    mock_executor = mocker.patch("processes.grin.unpack.executor")
+
+    mock_s3_client.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}}, "head_object"
+    )
+
+    result = service.unpack_barcode_package(barcode)
+
+    mock_s3_client.download_file.assert_called_once_with(
+        Bucket=service.bucket,
+        Key=f"{ocr_dir}{ocr_package_name}",
+        Filename="/mocked/temp/path/file.tar.gz.gpg",
+    )
+    mock_download_service.decrypt_ocr_package.assert_called_once_with(
+        barcode, mocker.ANY, mocker.ANY
+    )
+    mock_tarfile_open.assert_called_once_with(decrypted_package_path, mode="r|*")
+    assert mock_executor.submit.call_count == 2
+
+    expected_calls = [
+        mocker.call(
+            service._upload_file_to_s3, ocr_dir, "file1.txt", b"content of file 1"
+        ),
+        mocker.call(
+            service._upload_file_to_s3, ocr_dir, "file2.jpg", b"content of file 2"
+        ),
+    ]
+    mock_executor.submit.assert_has_calls(expected_calls, any_order=True)
+
+    expected_files = {
+        "file1.txt": b"content of file 1",
+        "file2.jpg": b"content of file 2",
+    }
+    assert result == expected_files
+
+
+def test_unpack_barcode_package_tar_error(mock_unpack_service, mocker):
+    service, _, mock_download_service = mock_unpack_service
+    barcode = "12345"
+
+    mocker.patch("processes.grin.unpack.tempfile.TemporaryDirectory")
+    mock_download_service.decrypt_ocr_package.return_value = (
+        "/tmp/decrypted/file.tar.gz"
+    )
+
+    mocker.patch(
+        "processes.grin.unpack.tarfile.open",
+        side_effect=tarfile.TarError("Corrupt file"),
+    )
+
+    with pytest.raises(Exception, match="Failed to unpack OCR package for 12345"):
+        service.unpack_barcode_package(barcode)
+
+
+def test_upload_file_to_s3_success(mock_unpack_service):
+    service, mock_s3_client, _ = mock_unpack_service
+
+    mock_s3_client.head_object.side_effect = ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}}, "head_object"
+    )
+
+    file_data = b"test data"
+    service._upload_file_to_s3("test_dir/", "test_file.txt", file_data)
+
+    mock_s3_client.head_object.assert_called_once_with(
+        Bucket=service.bucket, Key="test_dir/test_file.txt"
+    )
+    mock_s3_client.put_object.assert_called_once()
+
+    args, kwargs = mock_s3_client.put_object.call_args
+    assert kwargs["Body"] == file_data
+    assert kwargs["Bucket"] == service.bucket
+    assert kwargs["Key"] == "test_dir/test_file.txt"
+
+    expiration_time = kwargs["Expires"]
+    assert isinstance(expiration_time, datetime)
+    time_difference = expiration_time - datetime.now(timezone.utc)
+    assert (
+        timedelta(weeks=1) - timedelta(minutes=5)
+        < time_difference
+        < timedelta(weeks=1) + timedelta(minutes=5)
+    )
+
+
+def test_upload_file_to_s3_skip_existing(mock_unpack_service):
+    service, mock_s3_client, _ = mock_unpack_service
+
+    mock_s3_client.head_object.return_value = {}
+
+    file_data = b"test data"
+    service._upload_file_to_s3("test_dir/", "test_file.txt", file_data)
+
+    mock_s3_client.head_object.assert_called_once()
+    mock_s3_client.put_object.assert_not_called()
+
+
+def test_upload_file_to_s3_client_error(mock_unpack_service):
+    service, mock_s3_client, _ = mock_unpack_service
+
+    mock_s3_client.head_object.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}, "head_object"
+    )
+
+    with pytest.raises(ClientError):
+        service._upload_file_to_s3("test_dir/", "test_file.txt", b"test data")

--- a/etl-pipeline/tests/unit/grin/test_unpack.py
+++ b/etl-pipeline/tests/unit/grin/test_unpack.py
@@ -31,15 +31,11 @@ def test_unpack_barcode_package_success(mock_unpack_service, mocker):
     ocr_package_name = f"{barcode}.tar.gz.gpg"
     decrypted_package_path = f"/tmp/decrypted/{barcode}.tar.gz"
 
-    mock_path_join = mocker.patch(
-        "processes.grin.unpack.os.path.join",
-        side_effect=lambda *args: "/mocked/temp/path/file.tar.gz.gpg"
-        if args[1] == ocr_package_name
-        else os.path.join(*args),
-    )
+    real_join = os.path.join
+    def mock_join(*args):
+        return '/mocked/temp/path/file.tar.gz.gpg' if args[1] == ocr_package_name else real_join(*args)
 
-    mock_tmp_dir = mocker.patch("processes.grin.unpack.tempfile.TemporaryDirectory")
-    tmp_dir_path = mock_tmp_dir.return_value.__enter__.return_value
+    mocker.patch('processes.grin.unpack.os.path.join', side_effect=mock_join)
 
     mock_download_service.decrypt_ocr_package.return_value = decrypted_package_path
 

--- a/etl-pipeline/tests/unit/grin/test_unpack.py
+++ b/etl-pipeline/tests/unit/grin/test_unpack.py
@@ -137,6 +137,7 @@ def test_upload_file_to_s3_success(mock_unpack_service):
     assert kwargs["Key"] == "test_dir/test_file.txt"
     assert kwargs["Tagging"] == "retention=7days"
 
+
 def test_upload_file_to_s3_skip_existing(mock_unpack_service):
     service, mock_s3_client, _ = mock_unpack_service
 


### PR DESCRIPTION
[SCHOL-120](https://newyorkpubliclibrary.atlassian.net/browse/SCHOL-120)

Branched from vra-jamz

## Describe your changes
- Adds GRINUnpackService that is called from the `/item/{item_id}/read/{page_id}` endpoint when the files have not been unpacked and uploaded to S3

Future considerations:
- Each time the next page is loaded, the tar file needs to be downloaded and unpacked. We should look into caching the files for the session or a set time period.

Speed demo from my local-qa env
https://github.com/user-attachments/assets/cd4a0b46-5be6-4ff7-9ccc-1aa1cf503d0a

## How to test
The barcode (33433008478368) linked to the item tested above is in `drb-files-limited-qa` as an unpacked tar file.

[SCHOL-120]: https://newyorkpubliclibrary.atlassian.net/browse/SCHOL-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ